### PR TITLE
Compile regex patterns as constants in NameNormalizer

### DIFF
--- a/src/commonMain/kotlin/match/NameNormalizer.kt
+++ b/src/commonMain/kotlin/match/NameNormalizer.kt
@@ -2,15 +2,21 @@ package match
 
 // Multiplatform-safe name normalization (simplified, no Unicode decomposition)
 object NameNormalizer {
+    private val PUNCTUATION = "[,'`\u2019]".toRegex()
+    private val DASHES = "[-\u2013\u2014]".toRegex()
+    private val QUOTES = "[\"]".toRegex()
+    private val NON_ALNUM = "[^a-z0-9 ]".toRegex()
+    private val WHITESPACE = "\\s+".toRegex()
+
     fun normalize(raw: String): String {
         val lower = raw.lowercase()
         val replaced = lower
-            .replace("[,'`’]".toRegex(), "")
-            .replace("[-–—]".toRegex(), " ")
-            .replace("[\"]".toRegex(), "")
+            .replace(PUNCTUATION, "")
+            .replace(DASHES, " ")
+            .replace(QUOTES, "")
         val primary = replaced.split(" // ").first()
-        return primary.replace("[^a-z0-9 ]".toRegex(), " ")
-            .replace("\\s+".toRegex(), " ")
+        return primary.replace(NON_ALNUM, " ")
+            .replace(WHITESPACE, " ")
             .trim()
     }
 }


### PR DESCRIPTION
This change optimizes the `NameNormalizer.normalize()` function by moving five regex patterns into private constants. Previously, these regexes were created via `.toRegex()` on every call to `normalize()`, which is called frequently during card variant parsing and matching. By moving them to constants within the `NameNormalizer` object, they are now compiled only once when the object is first accessed.

I have verified the change by ensuring the project compiles for both common and desktop targets. No functional changes were made to the regex logic itself, preserving existing behavior while improving performance.

Fixes #67

---
*PR created automatically by Jules for task [2921180163182796364](https://jules.google.com/task/2921180163182796364) started by @srMarlins*