### PR TITLE
Remove changed flag no-op and fix fillZeroPrices

### DIFF
--- a/src/commonMain/kotlin/catalog/KtorRemoteCatalogDataSource.kt
+++ b/src/commonMain/kotlin/catalog/KtorRemoteCatalogDataSource.kt
@@ -61,16 +61,15 @@ class KtorRemoteCatalogDataSource(private val client: HttpClient? = null) : Cata
             "Holo" to 300,
             "Foil" to 350
         )
-        var changed = false
         val updated = catalog.variants.map { v ->
+            val t = canonicalType(v.variantType)
             if (v.priceInCents <= 0) {
-                changed = true
-                val t = canonicalType(v.variantType)
                 v.copy(priceInCents = centsMap[t] ?: 0, variantType = t)
-            } else v.copy(variantType = canonicalType(v.variantType))
+            } else {
+                v.copy(variantType = t)
+            }
         }
-        val fixed = Catalog(updated)
-        return if (changed) fixed else fixed
+        return Catalog(updated)
     }
 
     private fun canonicalType(raw: String): String {

--- a/src/desktopMain/kotlin/catalog/RemoteCatalogDataSource.kt
+++ b/src/desktopMain/kotlin/catalog/RemoteCatalogDataSource.kt
@@ -41,17 +41,15 @@ class RemoteCatalogDataSource : CatalogDataSource {
             "Holo" to 300,
             "Foil" to 350
         )
-        var changed = false
         val updated = catalog.variants.map { v ->
+            val t = canonicalType(v.variantType)
             if (v.priceInCents <= 0) {
-                changed = true
-                val t = canonicalType(v.variantType)
                 v.copy(priceInCents = centsMap[t] ?: 0, variantType = t)
-            } else v.copy(variantType = canonicalType(v.variantType))
+            } else {
+                v.copy(variantType = t)
+            }
         }
-        val fixed = Catalog(updated)
-        // Keep same structure
-        return if (changed) fixed else fixed
+        return Catalog(updated)
     }
 
     override suspend fun load(forceRefresh: Boolean, log: (String) -> Unit): Catalog? = withContext(Dispatchers.IO) {


### PR DESCRIPTION
Removed the redundant `changed` flag in `fillZeroPrices` in both common and desktop tracks. The function now always returns the updated catalog directly, as both branches of the previous conditional were returning the same result. The mapping logic was also simplified by extracting the canonicalized type into a local variable.

Fixes #76

---
*PR created automatically by Jules for task [8700448059220078393](https://jules.google.com/task/8700448059220078393) started by @srMarlins*