### PR TITLE
Remove unnecessary expect/actual for maxOf, minOf, abs

### DIFF
--- a/src/commonMain/kotlin/match/Levenshtein.kt
+++ b/src/commonMain/kotlin/match/Levenshtein.kt
@@ -1,5 +1,7 @@
 package match
 
+import kotlin.math.min
+
 object Levenshtein {
     fun distance(a: String, b: String): Int {
         if (a == b) return 0
@@ -14,10 +16,9 @@ object Levenshtein {
             for (j in 1..n) {
                 val temp = dp[j]
                 val cost = if (a[i - 1] == b[j - 1]) 0 else 1
-                dp[j] = minOf(
-                    dp[j] + 1,      // deletion
-                    dp[j - 1] + 1,  // insertion
-                    prev + cost     // substitution
+                dp[j] = min(
+                    min(dp[j] + 1, dp[j - 1] + 1), // deletion or insertion
+                    prev + cost                    // substitution
                 )
                 prev = temp
             }

--- a/src/commonMain/kotlin/platform/PlatformUtils.kt
+++ b/src/commonMain/kotlin/platform/PlatformUtils.kt
@@ -16,21 +16,6 @@ expect fun currentTimeMillis(): Long
 expect fun formatDecimal(value: Double, decimalPlaces: Int): String
 
 /**
- * Get maximum of two Int values.
- */
-expect fun maxOf(a: Int, b: Int): Int
-
-/**
- * Get minimum of two Int values.
- */
-expect fun minOf(a: Int, b: Int): Int
-
-/**
- * Get absolute value of an Int.
- */
-expect fun abs(value: Int): Int
-
-/**
  * Copy text to system clipboard.
  */
 expect suspend fun copyToClipboard(text: String)

--- a/src/commonMain/kotlin/ui/PixelComponents.kt
+++ b/src/commonMain/kotlin/ui/PixelComponents.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
+import kotlin.math.max
 
 // ========================================
 // PIXEL SHAPE (for matching border clipping)
@@ -482,7 +483,7 @@ fun Modifier.pixelBorder(
         val innerPath = createPixelPath(
             width = size.width - strokeWidth * 2,
             height = size.height - strokeWidth * 2,
-            cornerSize = maxOf(0f, cornerPx - strokeWidth)
+            cornerSize = max(0f, cornerPx - strokeWidth)
         )
         innerPath.translate(Offset(strokeWidth, strokeWidth))
         

--- a/src/commonMain/kotlin/ui/StepperComponent.kt
+++ b/src/commonMain/kotlin/ui/StepperComponent.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import kotlin.math.max
+import kotlin.math.min
 
 enum class StepState {
     COMPLETED,
@@ -293,8 +295,8 @@ fun RowScope.PixelStepConnector(
                     while (progressX < progressWidth) {
                         // Only draw if the bar is within the progress area
                         if (progressX + patternSize > 0) {
-                            val barStart = maxOf(0f, progressX)
-                            val barEnd = minOf(progressWidth, progressX + patternSize)
+                            val barStart = max(0f, progressX)
+                            val barEnd = min(progressWidth, progressX + patternSize)
                             val barWidth = barEnd - barStart
 
                             if (barWidth > 0) {

--- a/src/desktopMain/kotlin/platform/PlatformUtils.kt
+++ b/src/desktopMain/kotlin/platform/PlatformUtils.kt
@@ -9,12 +9,6 @@ actual fun formatDecimal(value: Double, decimalPlaces: Int): String {
     return "$" + "%.${decimalPlaces}f".format(value)
 }
 
-actual fun maxOf(a: Int, b: Int): Int = Math.max(a, b)
-
-actual fun minOf(a: Int, b: Int): Int = Math.min(a, b)
-
-actual fun abs(value: Int): Int = Math.abs(value)
-
 actual suspend fun copyToClipboard(text: String) {
     try {
         val clipboard = Toolkit.getDefaultToolkit().systemClipboard

--- a/src/iosMain/kotlin/platform/PlatformUtils.kt
+++ b/src/iosMain/kotlin/platform/PlatformUtils.kt
@@ -2,9 +2,6 @@ package platform
 
 import platform.Foundation.NSDate
 import platform.Foundation.timeIntervalSince1970
-import kotlin.math.pow
-import kotlin.math.round
-import kotlin.math.abs as kAbs
 
 actual fun currentTimeMillis(): Long = (NSDate().timeIntervalSince1970 * 1000).toLong()
 
@@ -16,12 +13,6 @@ actual fun formatDecimal(value: Double, decimalPlaces: Int): String {
     val formatted = formatter.stringFromNumber(platform.Foundation.NSNumber(value))
     return "$$formatted"
 }
-
-actual fun maxOf(a: Int, b: Int): Int = if (a > b) a else b
-
-actual fun minOf(a: Int, b: Int): Int = if (a < b) a else b
-
-actual fun abs(value: Int): Int = kAbs(value)
 
 actual suspend fun copyToClipboard(text: String) {
     platform.UIKit.UIPasteboard.generalPasteboard.string = text


### PR DESCRIPTION
Removed redundant `expect`/`actual` declarations for `maxOf`, `minOf`, and `abs` and replaced their call sites with `kotlin.math.max`, `kotlin.math.min`, and `kotlin.math.abs`. Verified that no other usages remain and that the code compiles correctly across all platforms.

Fixes #68

---
*PR created automatically by Jules for task [17548149461439017071](https://jules.google.com/task/17548149461439017071) started by @srMarlins*