### PR TITLE
Add CI concurrency control and job timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,15 @@ on:
   pull_request:
     branches: [ "main" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-desktop:
     name: Build Desktop (JVM)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       
@@ -28,6 +33,7 @@ jobs:
   build-ios-check:
     name: Build iOS (Check)
     runs-on: macos-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,10 +36,15 @@ on:
         default: 'ad-hoc'
         required: false
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   setup:
     name: Setup & Versioning
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       APP_VERSION: ${{ steps.version.outputs.APP_VERSION }}
       RUN_WINDOWS: ${{ steps.filter.outputs.RUN_WINDOWS }}
@@ -102,6 +107,7 @@ jobs:
     needs: setup
     if: ${{ needs.setup.outputs.RUN_WINDOWS == 'true' }}
     runs-on: windows-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -135,6 +141,7 @@ jobs:
     needs: setup
     if: ${{ needs.setup.outputs.RUN_MACOS == 'true' }}
     runs-on: macos-latest
+    timeout-minutes: 30
     env:
       SIGN_MAC: ${{ (github.event_name == 'workflow_dispatch' && inputs.sign_mac) || (secrets.SIGN_MAC == 'true') }}
       APP_VERSION: ${{ needs.setup.outputs.APP_VERSION }}
@@ -180,6 +187,7 @@ jobs:
     needs: setup
     if: ${{ needs.setup.outputs.RUN_IOS == 'true' }}
     runs-on: macos-latest
+    timeout-minutes: 30
     env:
       SIGN_IOS: ${{ (github.event_name == 'workflow_dispatch' && inputs.sign_ios) || (secrets.SIGN_IOS == 'true') }}
       APP_VERSION: ${{ needs.setup.outputs.APP_VERSION }}
@@ -266,6 +274,7 @@ jobs:
     needs: [setup, build-windows, build-macos, build-ios]
     if: ${{ github.event_name == 'release' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
This change adds concurrency control and job timeouts to the GitHub Actions workflows. 
- Concurrency control ensures that only one workflow run is active per branch/ref, canceling older runs when a new push occurs. This saves runner minutes, especially on expensive macOS runners.
- Job timeouts set a 30-minute limit on all jobs, preventing hung processes from consuming excessive resources.

Fixes #72

---
*PR created automatically by Jules for task [7786377006144445786](https://jules.google.com/task/7786377006144445786) started by @srMarlins*