### PR TITLE
Fix race condition in ScryfallImageEnricher rate limiter

### DIFF
--- a/src/commonMain/kotlin/catalog/ScryfallImageEnricher.kt
+++ b/src/commonMain/kotlin/catalog/ScryfallImageEnricher.kt
@@ -1,6 +1,8 @@
 package catalog
 
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import model.CardVariant
 import platform.currentTimeMillis
 
@@ -10,6 +12,7 @@ import platform.currentTimeMillis
  */
 object ScryfallImageEnricher {
     private const val RATE_LIMIT_DELAY_MS = 100L // 10 requests per second
+    private val mutex = Mutex()
     private var lastRequestTime = 0L
 
     /**
@@ -30,13 +33,15 @@ object ScryfallImageEnricher {
         // Skip if already has an image URL
         if (variant.imageUrl != null) return variant
 
-        // Rate limiting
-        val now = currentTimeMillis()
-        val timeSinceLastRequest = now - lastRequestTime
-        if (timeSinceLastRequest < RATE_LIMIT_DELAY_MS) {
-            delay(RATE_LIMIT_DELAY_MS - timeSinceLastRequest)
+        // Rate limiting — synchronized to prevent concurrent coroutines from bypassing the limit
+        mutex.withLock {
+            val now = currentTimeMillis()
+            val timeSinceLastRequest = now - lastRequestTime
+            if (timeSinceLastRequest < RATE_LIMIT_DELAY_MS) {
+                delay(RATE_LIMIT_DELAY_MS - timeSinceLastRequest)
+            }
+            lastRequestTime = currentTimeMillis()
         }
-        lastRequestTime = currentTimeMillis()
 
         try {
             val imageUrl = if (variant.collectorNumber != null) {


### PR DESCRIPTION
## Summary
- Add `Mutex` to synchronize access to `lastRequestTime` in the `ScryfallImageEnricher` singleton
- Prevents concurrent coroutines from bypassing the Scryfall API rate limit by racing on the shared mutable state
- The `mutex.withLock {}` block serializes the read-check-delay-update cycle while allowing actual API calls to proceed concurrently

## Test plan
- [ ] Verify `./gradlew build` compiles successfully
- [ ] Run the app and trigger image enrichment for multiple cards
- [ ] Confirm Scryfall API calls are properly rate-limited under concurrent load

Closes #50