### PR TITLE
Fix runBlocking inside coroutine context

### DIFF
--- a/src/commonMain/kotlin/catalog/KtorRemoteCatalogDataSource.kt
+++ b/src/commonMain/kotlin/catalog/KtorRemoteCatalogDataSource.kt
@@ -82,10 +82,10 @@ class KtorRemoteCatalogDataSource(private val client: HttpClient? = null) : Cata
         }
     }
 
-    private fun fetchAllCsvPages(client: HttpClient, log: (String) -> Unit): String {
+    private suspend fun fetchAllCsvPages(client: HttpClient, log: (String) -> Unit): String {
         // Try direct CSV
         log("Attempting direct CSV fetch: $urlApi")
-        runCatching { runBlockingLike { fetchRaw(client, urlApi, log) } }
+        runCatching { fetchRaw(client, urlApi, log) }
             .onSuccess { csv -> if (csv.isNotBlank()) return csv }
             .onFailure { ex -> log("Direct CSV fetch failed: ${ex.message}") }
 
@@ -97,7 +97,7 @@ class KtorRemoteCatalogDataSource(private val client: HttpClient? = null) : Cata
         while (page <= maxPages) {
             val url = "$urlApi?page=$page"
             log("Fetching CSV page: $url")
-            val csv = runCatching { runBlockingLike { fetchRaw(client, url, log) } }.getOrNull() ?: break
+            val csv = runCatching { fetchRaw(client, url, log) }.getOrNull() ?: break
             val lines = csv.lines().filter { it.isNotBlank() }
             if (lines.isEmpty()) break
             val bodyHash = lines.drop(1).joinToString("\n").hashCode()
@@ -115,9 +115,6 @@ class KtorRemoteCatalogDataSource(private val client: HttpClient? = null) : Cata
         }
         return allRows.joinToString("\n")
     }
-
-    // Helper to call suspend fetchRaw inside non-suspend context used above
-    private fun <T> runBlockingLike(block: suspend () -> T): T = kotlinx.coroutines.runBlocking { block() }
 
     private suspend fun fetchRaw(client: HttpClient, url: String, log: (String) -> Unit): String {
         val resp = client.get(url) {


### PR DESCRIPTION
## Summary
- Make `fetchAllCsvPages` a `suspend` function instead of using `runBlocking` bridge
- Remove the `runBlockingLike` helper that wrapped `kotlinx.coroutines.runBlocking`
- This prevents potential deadlocks on limited thread pools (especially iOS single-threaded main dispatcher)
- All pagination logic preserved; only the blocking bridge was removed

## Test plan
- [ ] Verify `./gradlew build` compiles successfully
- [ ] Run the app and load a catalog with pagination
- [ ] Verify catalog loads successfully on both desktop and iOS

Closes #51