### PR TITLE
Fix floating-point price truncation in catalog parsers

### DIFF
--- a/src/commonMain/kotlin/catalog/CatalogCsvParser.kt
+++ b/src/commonMain/kotlin/catalog/CatalogCsvParser.kt
@@ -1,5 +1,6 @@
 package catalog
 
+import kotlin.math.roundToInt
 import match.NameNormalizer
 import model.CardVariant
 import model.Catalog
@@ -118,7 +119,7 @@ object CatalogCsvParser {
                 val key = type.lowercase()
                 mapLower[key] ?: defaultsLower[key] ?: 0.0
             }
-            val priceCents = (priceDollars * 100.0).toInt()
+            val priceCents = (priceDollars * 100.0).roundToInt()
             variants += CardVariant(
                 nameOriginal = name,
                 nameNormalized = NameNormalizer.normalize(name),

--- a/src/commonMain/kotlin/catalog/CatalogParser.kt
+++ b/src/commonMain/kotlin/catalog/CatalogParser.kt
@@ -1,6 +1,7 @@
 package catalog
 
 import com.fleeksoft.ksoup.Ksoup
+import kotlin.math.roundToInt
 import model.CardVariant
 import model.Catalog
 import match.NameNormalizer
@@ -142,7 +143,7 @@ object CatalogParser {
         val cleaned = raw.replace("[^0-9.]".toRegex(), "")
         if (cleaned.isBlank()) return 0
         return try {
-            (cleaned.toDouble() * 100).toInt()
+            (cleaned.toDouble() * 100).roundToInt()
         } catch (_: NumberFormatException) {
             0
         }


### PR DESCRIPTION
## Summary
- Replace `(priceDollars * 100.0).toInt()` with `(priceDollars * 100.0).roundToInt()` in both CatalogCsvParser and CatalogParser
- Fixes IEEE 754 truncation bug where `2.20 * 100 = 219.99999...` became 219 cents instead of 220
- Uses idiomatic `kotlin.math.roundToInt()` 

## Test plan
- [ ] Verify `./gradlew build` compiles successfully
- [ ] Load a catalog and verify prices display correctly (e.g., Regular = $2.20, not $2.19)
- [ ] Spot-check several card prices against the CSV source

Closes #52