### PR TITLE
Wrap catalog replacement in database transaction

### DIFF
--- a/src/commonMain/kotlin/database/CatalogStore.kt
+++ b/src/commonMain/kotlin/database/CatalogStore.kt
@@ -25,13 +25,7 @@ class CatalogStore(private val database: Database) {
      * This is typically called after fetching from a remote source.
      */
     suspend fun replaceCatalog(catalog: Catalog) {
-        // Clear existing variants
-        database.clearAllVariants()
-        
-        // Insert all new variants
-        catalog.variants.forEach { variant ->
-            database.insertVariant(variant)
-        }
+        database.replaceCatalogTransaction(catalog.variants)
     }
     
     /**

--- a/src/commonMain/kotlin/database/Database.kt
+++ b/src/commonMain/kotlin/database/Database.kt
@@ -106,4 +106,22 @@ class Database(databaseDriverFactory: DatabaseDriverFactory) {
     suspend fun updateVariantImageUrl(sku: String, imageUrl: String) {
         db.cardVariantQueries.updateImageUrl(imageUrl = imageUrl, sku = sku)
     }
+
+    fun replaceCatalogTransaction(variants: List<CardVariant>) {
+        db.transaction {
+            db.cardVariantQueries.deleteAll()
+            variants.forEach { variant ->
+                db.cardVariantQueries.insertVariant(
+                    nameOriginal = variant.nameOriginal,
+                    nameNormalized = variant.nameNormalized,
+                    setCode = variant.setCode,
+                    sku = variant.sku,
+                    variantType = variant.variantType,
+                    priceInCents = variant.priceInCents.toLong(),
+                    collectorNumber = variant.collectorNumber,
+                    imageUrl = variant.imageUrl
+                )
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Add `replaceCatalogTransaction()` method to `Database.kt` that wraps clear + insert in `db.transaction {}`
- Update `CatalogStore.replaceCatalog()` to delegate to the new transactional method
- Ensures catalog replacement is atomic — users never see an empty or partial catalog during refresh
- New method operates directly on SQLDelight query objects inside the transaction block (suspend wrappers can't be called within synchronous transactions)

## Test plan
- [ ] Verify `./gradlew build` compiles successfully
- [ ] Load a catalog, then refresh it — verify no empty state flickers
- [ ] Kill the app during catalog refresh, relaunch — verify catalog is either fully old or fully new

Closes #53