### PR TITLE
Fix CSV injection vulnerability in CsvExporter

### DIFF
--- a/src/desktopMain/kotlin/export/CsvExporter.kt
+++ b/src/desktopMain/kotlin/export/CsvExporter.kt
@@ -19,7 +19,7 @@ object CsvExporter {
 
     private fun escapeCsvField(field: String): String {
         val escaped = field.replace("\"", "\"\"")
-        val safe = if (escaped.firstOrNull() in FORMULA_PREFIX_CHARS) "\t$escaped" else escaped
+        val safe = if (escaped.isNotEmpty() && escaped.first() in FORMULA_PREFIX_CHARS) "\t$escaped" else escaped
         return "\"$safe\""
     }
 


### PR DESCRIPTION
## Summary
- Add `escapeCsvField()` helper that double-quotes all fields, escapes internal quotes (`"` → `""`), and prefixes formula-triggering characters (`=`, `+`, `-`, `@`) with a tab character per OWASP recommendations
- Apply escaping to all CSV output fields in both `export()` and `exportWizardResults()` functions
- Prevents formula injection when exported CSVs are opened in Excel/Sheets (the app auto-opens via `Desktop.getDesktop().open()`)

## Test plan
- [ ] Verify `./gradlew build` compiles successfully
- [ ] Export a CSV and open in Excel — verify no formula execution warnings
- [ ] Export with a card name containing commas and quotes — verify proper escaping
- [ ] Verify summary rows are also properly quoted

Closes #55