### PR TITLE
Fix HTTP resource leaks and iOS UIPasteboard threading

### DIFF
--- a/src/commonMain/kotlin/catalog/ScryfallApi.kt
+++ b/src/commonMain/kotlin/catalog/ScryfallApi.kt
@@ -43,6 +43,15 @@ object ScryfallApi {
         }.also { httpClient = it }
     }
 
+    /**
+     * Close the underlying HttpClient to release resources.
+     * Should be called when the API is no longer needed.
+     */
+    fun close() {
+        httpClient?.close()
+        httpClient = null
+    }
+
     @Serializable
     data class ImageUris(
         val small: String? = null,

--- a/src/desktopMain/kotlin/catalog/RemoteCatalogDataSource.kt
+++ b/src/desktopMain/kotlin/catalog/RemoteCatalogDataSource.kt
@@ -194,13 +194,17 @@ class RemoteCatalogDataSource : CatalogDataSource {
             setRequestProperty("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) MtgPirate/1.0")
             setRequestProperty("Accept", "*/*")
         }
-        val code = conn.responseCode
-        log("HTTP GET $urlStr -> $code")
-        if (code !in 200..299) {
-            val err = conn.errorStream?.bufferedReader()?.use { it.readText() } ?: "HTTP $code without body"
-            throw IllegalStateException("Failed to fetch: $code $err")
+        try {
+            val code = conn.responseCode
+            log("HTTP GET $urlStr -> $code")
+            if (code !in 200..299) {
+                val err = conn.errorStream?.bufferedReader()?.use { it.readText() } ?: "HTTP $code without body"
+                throw IllegalStateException("Failed to fetch: $code $err")
+            }
+            return conn.inputStream.bufferedReader().use { it.readText() }
+        } finally {
+            conn.disconnect()
         }
-        return conn.inputStream.bufferedReader().use { it.readText() }
     }
 
     // Extract object literal CARD_TYPE_PRICES = { ... } mapping to Map<String, Double>

--- a/src/iosMain/kotlin/app/Main.kt
+++ b/src/iosMain/kotlin/app/Main.kt
@@ -21,6 +21,7 @@ import database.DatabaseDriverFactory
 import database.ImportsStore
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import platform.IosMviPlatformServices
 import state.MviViewModel
@@ -50,6 +51,14 @@ fun IosApp() {
             importsStore = importsStore,
             platformServices = platformServices
         )
+    }
+
+    // Clean up coroutine scope and HTTP client when composable leaves composition
+    DisposableEffect(Unit) {
+        onDispose {
+            platformServices.close()
+            scope.coroutineContext[Job]?.cancel()
+        }
     }
 
     // Collect view state

--- a/src/iosMain/kotlin/platform/IosMviPlatformServices.kt
+++ b/src/iosMain/kotlin/platform/IosMviPlatformServices.kt
@@ -34,6 +34,14 @@ class IosMviPlatformServices(
         install(Logging) { level = LogLevel.INFO }
     }
 
+    /**
+     * Close the underlying HttpClient to release resources.
+     * Should be called when the services are no longer needed.
+     */
+    fun close() {
+        httpClient.close()
+    }
+
     override suspend fun fetchCatalogFromRemote(log: (String) -> Unit): Catalog? {
         return withContext(Dispatchers.Default) {
             try {
@@ -118,7 +126,7 @@ class IosMviPlatformServices(
     }
 
     override suspend fun copyToClipboard(text: String) {
-        withContext(Dispatchers.Default) {
+        withContext(Dispatchers.Main) {
             platform.copyToClipboard(text)
         }
     }


### PR DESCRIPTION
## Summary
- **ScryfallApi.kt**: Add `close()` method to properly release the lazily-created HttpClient
- **RemoteCatalogDataSource.kt**: Wrap `fetchRaw()` in `try/finally` with `connection.disconnect()` to prevent connection leaks
- **IosMviPlatformServices.kt**: Add `close()` method for HttpClient lifecycle; change `copyToClipboard` from `Dispatchers.Default` to `Dispatchers.Main` for UIKit thread safety
- **Main.kt (iOS)**: Add `DisposableEffect` to cancel CoroutineScope and close platform services when composable leaves composition

## Test plan
- [ ] Verify `./gradlew build` compiles successfully
- [ ] Desktop: load catalog multiple times, verify no connection pool exhaustion
- [ ] iOS: copy results to clipboard — verify no crash from background thread UIKit access
- [ ] iOS: navigate away and back — verify resources are properly cleaned up

Closes #54
Closes #56