### PR TITLE
Add missing error handling on database operations

### DIFF
--- a/src/commonMain/kotlin/state/MviViewModel.kt
+++ b/src/commonMain/kotlin/state/MviViewModel.kt
@@ -168,16 +168,21 @@ class MviViewModel(
     private fun init() {
         scope.launch(Dispatchers.IO) {
             log("Initializing MVI ViewModel...", "INFO")
-            
-            // Check if catalog exists in database
-            val variantCount = catalogStore.getVariantCount()
-            
-            if (variantCount == 0L) {
-                // Catalog is empty, load from remote API
-                log("Catalog is empty, loading from remote...", "INFO")
-                loadCatalog()
-            } else {
-                log("Catalog already loaded: $variantCount variants", "INFO")
+
+            try {
+                // Check if catalog exists in database
+                val variantCount = catalogStore.getVariantCount()
+
+                if (variantCount == 0L) {
+                    // Catalog is empty, load from remote API
+                    log("Catalog is empty, loading from remote...", "INFO")
+                    loadCatalog()
+                } else {
+                    log("Catalog already loaded: $variantCount variants", "INFO")
+                }
+            } catch (e: Exception) {
+                log("Failed to check catalog: ${e.message}", "ERROR")
+                _viewEffects.emit(ViewEffect.ShowError("Failed to initialize catalog"))
             }
         }
     }
@@ -188,22 +193,37 @@ class MviViewModel(
 
     private fun toggleIncludeSideboard(value: Boolean) {
         scope.launch {
-            platformServices.updatePreferences { it.copy(includeSideboard = value) }
-            log("Include sideboard: $value", "INFO")
+            try {
+                platformServices.updatePreferences { it.copy(includeSideboard = value) }
+                log("Include sideboard: $value", "INFO")
+            } catch (e: Exception) {
+                log("Failed to save sideboard preference: ${e.message}", "ERROR")
+                _viewEffects.emit(ViewEffect.ShowError("Failed to save sideboard preference"))
+            }
         }
     }
 
     private fun toggleIncludeCommanders(value: Boolean) {
         scope.launch {
-            platformServices.updatePreferences { it.copy(includeCommanders = value) }
-            log("Include commanders: $value", "INFO")
+            try {
+                platformServices.updatePreferences { it.copy(includeCommanders = value) }
+                log("Include commanders: $value", "INFO")
+            } catch (e: Exception) {
+                log("Failed to save commanders preference: ${e.message}", "ERROR")
+                _viewEffects.emit(ViewEffect.ShowError("Failed to save commanders preference"))
+            }
         }
     }
 
     private fun toggleIncludeTokens(value: Boolean) {
         scope.launch {
-            platformServices.updatePreferences { it.copy(includeTokens = value) }
-            log("Include tokens: $value", "INFO")
+            try {
+                platformServices.updatePreferences { it.copy(includeTokens = value) }
+                log("Include tokens: $value", "INFO")
+            } catch (e: Exception) {
+                log("Failed to save tokens preference: ${e.message}", "ERROR")
+                _viewEffects.emit(ViewEffect.ShowError("Failed to save tokens preference"))
+            }
         }
     }
 
@@ -225,6 +245,7 @@ class MviViewModel(
             } catch (e: Exception) {
                 _localState.update { it.copy(catalogError = e.message) }
                 log("Catalog load exception: ${e.message}", "ERROR")
+                _viewEffects.emit(ViewEffect.ShowError("Failed to load catalog"))
             } finally {
                 _localState.update { it.copy(loadingCatalog = false) }
             }
@@ -439,22 +460,32 @@ class MviViewModel(
 
     private fun savePreferences(variantPriority: List<String>, setPriority: List<String>, fuzzyEnabled: Boolean) {
         scope.launch {
-            platformServices.updatePreferences {
-                it.copy(
-                    variantPriority = variantPriority,
-                    setPriority = setPriority,
-                    fuzzyEnabled = fuzzyEnabled
-                )
+            try {
+                platformServices.updatePreferences {
+                    it.copy(
+                        variantPriority = variantPriority,
+                        setPriority = setPriority,
+                        fuzzyEnabled = fuzzyEnabled
+                    )
+                }
+                log("Preferences saved", "INFO")
+                _localState.update { it.copy(showPreferences = false) }
+            } catch (e: Exception) {
+                log("Failed to save preferences: ${e.message}", "ERROR")
+                _viewEffects.emit(ViewEffect.ShowError("Failed to save preferences"))
             }
-            log("Preferences saved", "INFO")
-            _localState.update { it.copy(showPreferences = false) }
         }
     }
 
     private fun updateVariantPriority(newPriority: List<String>) {
         scope.launch {
-            platformServices.updatePreferences { it.copy(variantPriority = newPriority) }
-            log("Variant priority updated", "INFO")
+            try {
+                platformServices.updatePreferences { it.copy(variantPriority = newPriority) }
+                log("Variant priority updated", "INFO")
+            } catch (e: Exception) {
+                log("Failed to update variant priority: ${e.message}", "ERROR")
+                _viewEffects.emit(ViewEffect.ShowError("Failed to update variant priority"))
+            }
         }
     }
 
@@ -524,14 +555,20 @@ class MviViewModel(
                 includeTokens = preferences.includeTokens
             )
 
-            if (existing != null) {
-                // Update existing import (delete and re-add with new timestamp and cardCount)
-                importsStore.delete(existing.id)
-                importsStore.add(import)
-                log("Import updated: $generatedName", "INFO")
-            } else {
-                importsStore.add(import)
-                log("Import saved: $generatedName", "INFO")
+            try {
+                withContext(Dispatchers.IO) {
+                    if (existing != null) {
+                        // Update existing import (delete and re-add with new timestamp and cardCount)
+                        importsStore.delete(existing.id)
+                        importsStore.add(import)
+                    } else {
+                        importsStore.add(import)
+                    }
+                }
+                log(if (existing != null) "Import updated: $generatedName" else "Import saved: $generatedName", "INFO")
+            } catch (e: Exception) {
+                log("Failed to save import: ${e.message}", "ERROR")
+                _viewEffects.emit(ViewEffect.ShowError("Failed to save import"))
             }
         }
     }
@@ -540,31 +577,43 @@ class MviViewModel(
         scope.launch {
             val import = _viewState.value.savedImports.find { it.id == importId }
             if (import != null) {
-                platformServices.updatePreferences {
-                    it.copy(
-                        includeSideboard = import.includeSideboard,
-                        includeCommanders = import.includeCommanders,
-                        includeTokens = import.includeTokens
-                    )
-                }
+                try {
+                    platformServices.updatePreferences {
+                        it.copy(
+                            includeSideboard = import.includeSideboard,
+                            includeCommanders = import.includeCommanders,
+                            includeTokens = import.includeTokens
+                        )
+                    }
 
-                _localState.update {
-                    it.copy(
-                        deckText = import.deckText,
-                        showSavedImportsWindow = false,
-                        showResultsWindow = true
-                    )
-                }
+                    _localState.update {
+                        it.copy(
+                            deckText = import.deckText,
+                            showSavedImportsWindow = false,
+                            showResultsWindow = true
+                        )
+                    }
 
-                log("Loaded import: ${import.name}", "INFO")
+                    log("Loaded import: ${import.name}", "INFO")
+                } catch (e: Exception) {
+                    log("Failed to load import: ${e.message}", "ERROR")
+                    _viewEffects.emit(ViewEffect.ShowError("Failed to load saved import"))
+                }
             }
         }
     }
 
     private fun deleteSavedImport(importId: String) {
         scope.launch {
-            importsStore.delete(importId)
-            log("Import deleted", "INFO")
+            try {
+                withContext(Dispatchers.IO) {
+                    importsStore.delete(importId)
+                }
+                log("Import deleted", "INFO")
+            } catch (e: Exception) {
+                log("Failed to delete import: ${e.message}", "ERROR")
+                _viewEffects.emit(ViewEffect.ShowError("Failed to delete import"))
+            }
         }
     }
 
@@ -735,6 +784,7 @@ sealed class ViewIntent {
  */
 sealed class ViewEffect {
     data class ShowMessage(val message: String) : ViewEffect()
+    data class ShowError(val message: String) : ViewEffect()
 }
 
 /**


### PR DESCRIPTION
## Summary
- Wrap 10 unprotected database operations in try/catch blocks across MviViewModel
- Add `ViewEffect.ShowError(message)` sealed class variant for distinct error reporting
- Add `withContext(Dispatchers.IO)` to `saveCurrentImport()` and `deleteSavedImport()` for proper threading
- Error messages are user-friendly (e.g., "Failed to save import") without leaking technical details
- Operations covered: init catalog count, toggle sideboard/commanders/tokens, loadCatalog, savePreferences, updateVariantPriority, saveCurrentImport, loadSavedImport, deleteSavedImport

## Test plan
- [ ] Verify `./gradlew build` compiles successfully
- [ ] Save/load/delete imports — verify operations work normally
- [ ] Toggle preferences — verify settings persist correctly
- [ ] Simulate DB failure (e.g., full disk) — verify error message appears instead of crash

Closes #77