### PR TITLE
Add key parameter to LazyColumn items calls

### DIFF
--- a/src/commonMain/kotlin/deck/DecklistParser.kt
+++ b/src/commonMain/kotlin/deck/DecklistParser.kt
@@ -17,6 +17,7 @@ object DecklistParser {
         var sawSideboard = false
         var blankAfterSideboard = false
         val entries = mutableListOf<DeckEntry>()
+        var idCounter = 0
         for (raw in lines) {
             val lineOriginal = raw
             var line = raw.trim()
@@ -90,6 +91,7 @@ object DecklistParser {
                 Section.COMMANDER -> includeCommanders
             }
             entries += DeckEntry(
+                id = "entry_${idCounter++}",
                 originalLine = lineOriginal,
                 qty = qty,
                 cardName = cardName,

--- a/src/commonMain/kotlin/model/Models.kt
+++ b/src/commonMain/kotlin/model/Models.kt
@@ -12,7 +12,9 @@ data class CardVariant(
     val priceInCents: Int,
     val collectorNumber: String? = null,
     val imageUrl: String? = null
-)
+) {
+    val uniqueIdentifier: String get() = sku
+}
 
 @Serializable
 data class Catalog(
@@ -33,6 +35,7 @@ enum class Section { MAIN, SIDEBOARD, COMMANDER }
 // These are not serialized currently (runtime only) so exclude from @Serializable
 
 data class DeckEntry(
+    val id: String,
     val originalLine: String,
     val qty: Int,
     val cardName: String,
@@ -41,7 +44,9 @@ data class DeckEntry(
     val setCodeHint: String? = null,
     val collectorNumberHint: String? = null,
     val rawSetHint: String? = null
-)
+) {
+    val uniqueIdentifier: String get() = id
+}
 
 enum class MatchStatus { UNRESOLVED, AUTO_MATCHED, AMBIGUOUS, NOT_FOUND, MANUAL_SELECTED }
 
@@ -49,7 +54,9 @@ data class MatchCandidate(
     val variant: CardVariant,
     val score: Int,
     val reason: String
-)
+) {
+    val uniqueIdentifier: String get() = variant.sku
+}
 
 data class DeckEntryMatch(
     val deckEntry: DeckEntry,
@@ -57,7 +64,9 @@ data class DeckEntryMatch(
     val selectedVariant: CardVariant? = null,
     val candidates: List<MatchCandidate> = emptyList(),
     val notes: String = ""
-)
+) {
+    val uniqueIdentifier: String get() = deckEntry.id
+}
 
 @Serializable
 data class Preferences(
@@ -83,4 +92,6 @@ data class SavedImport(
     val includeSideboard: Boolean = false,
     val includeCommanders: Boolean = false,
     val includeTokens: Boolean = false
-)
+) {
+    val uniqueIdentifier: String get() = id
+}

--- a/src/commonMain/kotlin/ui/CatalogScreen.kt
+++ b/src/commonMain/kotlin/ui/CatalogScreen.kt
@@ -109,7 +109,7 @@ fun CatalogScreen(
                 val listState = rememberLazyListState()
                 Box(Modifier.fillMaxSize()) {
                     LazyColumn(Modifier.fillMaxSize(), state = listState) {
-                        items(filtered) { v ->
+                        items(filtered, key = { it.uniqueIdentifier }) { v ->
                             // Trigger image enrichment when variant comes into view
                             androidx.compose.runtime.LaunchedEffect(v.sku) {
                                 if (v.imageUrl == null) {

--- a/src/commonMain/kotlin/ui/ExportScreen.kt
+++ b/src/commonMain/kotlin/ui/ExportScreen.kt
@@ -100,7 +100,7 @@ fun ExportScreen(
                     }
                     Box(Modifier.fillMaxWidth().weight(1f, fill = true)) {
                         LazyColumn(Modifier.fillMaxSize(), state = matchedListState) {
-                            items(grouped.values.toList()) { group ->
+                            items(grouped.values.toList(), key = { it.first().selectedVariant!!.uniqueIdentifier }) { group ->
                                 val first = group.first().selectedVariant!!
                                 val qtyTotal = group.sumOf { it.deckEntry.qty }
                                 Row(Modifier.fillMaxWidth().padding(12.dp), verticalAlignment = Alignment.CenterVertically) {
@@ -132,7 +132,7 @@ fun ExportScreen(
                     } else {
                         Box(Modifier.fillMaxWidth().heightIn(max = 220.dp)) {
                             LazyColumn(Modifier.fillMaxSize(), state = unmatchedListState) {
-                                items(unresolved) { m ->
+                                items(unresolved, key = { it.uniqueIdentifier }) { m ->
                                     Row(Modifier.fillMaxWidth().padding(12.dp)) {
                                         Text("${m.deckEntry.qty}", Modifier.width(40.dp))
                                         Text(m.deckEntry.cardName, Modifier.weight(1f))

--- a/src/commonMain/kotlin/ui/MatchesScreen.kt
+++ b/src/commonMain/kotlin/ui/MatchesScreen.kt
@@ -134,7 +134,7 @@ fun MatchesScreen(
                 val listState = rememberLazyListState()
                 Box(Modifier.fillMaxSize()) {
                     LazyColumn(Modifier.fillMaxSize(), state = listState) {
-                        itemsIndexed(filtered) { index, m ->
+                        itemsIndexed(filtered, key = { _, m -> m.uniqueIdentifier }) { index, m ->
                             val v = m.selectedVariant
                             val price = v?.priceInCents
                             val rowTotal = price?.let { it * m.deckEntry.qty }

--- a/src/commonMain/kotlin/ui/ResolveScreen.kt
+++ b/src/commonMain/kotlin/ui/ResolveScreen.kt
@@ -123,7 +123,7 @@ fun ResolveScreen(
                     val listState = rememberLazyListState()
                     Box(Modifier.fillMaxSize()) {
                         LazyColumn(Modifier.fillMaxSize(), state = listState) {
-                            items(sorted) { cand: MatchCandidate ->
+                            items(sorted, key = { it.uniqueIdentifier }) { cand: MatchCandidate ->
                                 val variant = cand.variant
                                 
                                 // Trigger image enrichment when variant comes into view

--- a/src/commonMain/kotlin/ui/ResultsScreen.kt
+++ b/src/commonMain/kotlin/ui/ResultsScreen.kt
@@ -408,7 +408,7 @@ fun ResultsScreen(
                 val listState = rememberLazyListState()
                 Box(Modifier.fillMaxSize()) {
                     LazyColumn(Modifier.fillMaxSize(), state = listState) {
-                        itemsIndexed(sorted) { _, m ->
+                        itemsIndexed(sorted, key = { _, m -> m.uniqueIdentifier }) { _, m ->
                             val globalIndex = matches.indexOf(m)
                             val variant = m.selectedVariant
                             val rowTotal = variant?.priceInCents?.let { it * m.deckEntry.qty }

--- a/src/desktopMain/kotlin/ui/DesktopResolveScreen.kt
+++ b/src/desktopMain/kotlin/ui/DesktopResolveScreen.kt
@@ -131,7 +131,7 @@ fun DesktopResolveScreen(
                     val listState = rememberLazyListState()
                     Box(Modifier.fillMaxSize()) {
                         LazyColumn(Modifier.fillMaxSize(), state = listState) {
-                            items(sorted) { cand: MatchCandidate ->
+                            items(sorted, key = { it.uniqueIdentifier }) { cand: MatchCandidate ->
                                 val variant = cand.variant
                                 
                                 // Trigger image enrichment when variant comes into view

--- a/src/desktopMain/kotlin/ui/DesktopSavedImportsDialog.kt
+++ b/src/desktopMain/kotlin/ui/DesktopSavedImportsDialog.kt
@@ -144,7 +144,7 @@ actual fun SavedImportsDialog(
                                 verticalArrangement = Arrangement.spacedBy(8.dp),
                                 state = listState
                             ) {
-                                items(savedImports) { import ->
+                                items(savedImports, key = { it.uniqueIdentifier }) { import ->
                                     SavedImportCard(
                                         import = import,
                                         onSelect = { onSelectImport(import.id) },

--- a/src/iosMain/kotlin/app/IosScreens.kt
+++ b/src/iosMain/kotlin/app/IosScreens.kt
@@ -488,7 +488,7 @@ fun IosResolveScreen(
                             state = listState,
                             verticalArrangement = Arrangement.spacedBy(12.dp)
                         ) {
-                            items(sorted) { cand: model.MatchCandidate ->
+                            items(sorted, key = { it.uniqueIdentifier }) { cand: model.MatchCandidate ->
                                 val variant = cand.variant
                                 
                                 // Trigger image enrichment

--- a/src/iosMain/kotlin/ui/IosSavedImportsDialog.kt
+++ b/src/iosMain/kotlin/ui/IosSavedImportsDialog.kt
@@ -159,7 +159,7 @@ actual fun SavedImportsDialog(
                                     verticalArrangement = Arrangement.spacedBy(8.dp),
                                     state = listState
                                 ) {
-                                    items(savedImports) { import ->
+                                    items(savedImports, key = { it.uniqueIdentifier }) { import ->
                                         MobileSavedImportCard(
                                             import = import,
                                             onSelect = { onSelectImport(import.id) },

--- a/src/iosMain/kotlin/ui/MobileResultsScreen.kt
+++ b/src/iosMain/kotlin/ui/MobileResultsScreen.kt
@@ -354,7 +354,7 @@ fun MobileResultsScreen(
                 val listState = rememberLazyListState()
                 Box(Modifier.fillMaxSize()) {
                     LazyColumn(Modifier.fillMaxSize(), state = listState) {
-                        itemsIndexed(sorted) { _, m ->
+                        itemsIndexed(sorted, key = { _, m -> m.uniqueIdentifier }) { _, m ->
                             val globalIndex = matches.indexOf(m)
                             val variant = m.selectedVariant
                             val rowTotal = variant?.priceInCents?.let { it * m.deckEntry.qty }


### PR DESCRIPTION
This PR adds stable keys to all LazyColumn items in the project. By using the `key` parameter, we ensure that Jetpack Compose can efficiently track item identity, leading to better performance and preserved state during list mutations (like filtering or reordering).

Summary of changes:
1. **Model Updates**: Added a `uniqueIdentifier` abstraction across model classes. `DeckEntry` now has an `id` field.
2. **Parser Update**: `DecklistParser` now assigns a unique incrementing ID to each `DeckEntry`.
3. **UI Updates**: All `items()` and `itemsIndexed()` calls in `LazyColumn` now use `key = { ...uniqueIdentifier }`.

Files modified:
- `src/commonMain/kotlin/model/Models.kt`
- `src/commonMain/kotlin/deck/DecklistParser.kt`
- `src/desktopMain/kotlin/ui/DesktopResolveScreen.kt`
- `src/desktopMain/kotlin/ui/DesktopSavedImportsDialog.kt`
- `src/iosMain/kotlin/app/IosScreens.kt`
- `src/iosMain/kotlin/ui/MobileResultsScreen.kt`
- `src/iosMain/kotlin/ui/IosSavedImportsDialog.kt`
- `src/commonMain/kotlin/ui/ResolveScreen.kt`
- `src/commonMain/kotlin/ui/ResultsScreen.kt`
- `src/commonMain/kotlin/ui/MatchesScreen.kt`
- `src/commonMain/kotlin/ui/ExportScreen.kt`
- `src/commonMain/kotlin/ui/CatalogScreen.kt`

Fixes #71

---
*PR created automatically by Jules for task [10564556749393757039](https://jules.google.com/task/10564556749393757039) started by @srMarlins*