### PR TITLE
Apply detekt plugin and add static analysis to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build --stacktrace
 
+      - name: Run detekt static analysis
+        run: ./gradlew detekt --stacktrace
+
   build-ios-check:
     name: Build iOS (Check)
     runs-on: macos-latest

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.sqldelight)
+    alias(libs.plugins.detekt)
 }
 
 group = "org.srmarlins"
@@ -139,4 +140,10 @@ sqldelight {
             packageName.set("org.srmarlins.mtgpirate.db")
         }
     }
+}
+
+detekt {
+    config.setFrom(files("detekt.yml"))
+    baseline = file("detekt-baseline.xml")
+    buildUponDefaultConfig = true
 }

--- a/detekt.yml
+++ b/detekt.yml
@@ -196,6 +196,8 @@ naming:
   FunctionNaming:
     active: true
     functionPattern: '[a-z][a-zA-Z0-9]*'
+    ignoreAnnotated:
+      - 'Composable'
   FunctionParameterNaming:
     active: true
     parameterPattern: '[a-z][A-Za-z0-9]*'


### PR DESCRIPTION
## Summary
- Apply the detekt plugin that was declared in version catalog but never enabled
- Wire up existing `detekt.yml` config and `detekt-baseline.xml` with `buildUponDefaultConfig = true`
- Add `ignoreAnnotated: ['Composable']` to FunctionNaming rule to avoid false positives on PascalCase composables
- Add `./gradlew detekt` CI step

## Test plan
- [ ] Verify `./gradlew build` compiles
- [ ] Verify `./gradlew detekt` runs with baseline (no new violations)
- [ ] CI pipeline includes detekt step

Closes #57