### PR TITLE
Fix ProGuard rules: remove Room, add Ktor/SLF4J

### DIFF
--- a/compose-desktop.pro
+++ b/compose-desktop.pro
@@ -9,15 +9,10 @@
 # Keep all JDBC drivers (they use Class.forName)
 -keep class * implements java.sql.Driver { *; }
 
-# Keep database-related classes that might use reflection
--keepclassmembers class * {
-    @androidx.room.** *;
-}
-
 # Prevent obfuscation of SQL-related classes
 -keep class java.sql.** { *; }
 
-# Keep Kotlin coroutines for database operations
+# Keep Kotlin coroutines for database and Ktor operations
 -keepclassmembers class kotlinx.coroutines.** {
     volatile <fields>;
 }
@@ -34,10 +29,14 @@
     kotlinx.serialization.KSerializer serializer(...);
 }
 
-# Keep Compose runtime
--keep class androidx.compose.** { *; }
--keep class androidx.compose.runtime.** { *; }
+# Ktor CIO engine uses reflection
+-keep class io.ktor.** { *; }
+-keep class kotlinx.coroutines.** { *; }
+-dontwarn io.ktor.**
 
-# Don't warn about missing classes
+# SLF4J service provider interface
+-keep class org.slf4j.** { *; }
 -dontwarn org.slf4j.**
+
+# Don't warn about missing optional logging backends
 -dontwarn org.apache.log4j.**


### PR DESCRIPTION
## Summary
- Remove dead Room annotation keep rules (project uses SQLDelight)
- Add Ktor CIO engine keep rules to prevent reflection crashes in release builds
- Add SLF4J `-keep` rule (previously only had `-dontwarn`)
- Remove blanket `-keep class androidx.compose.** { *; }` (Compose plugin handles this)
- Existing SQLDelight, JDBC, and Kotlin serialization rules preserved

## Test plan
- [ ] Verify `./gradlew build` compiles
- [ ] Build release package and verify it launches correctly
- [ ] Verify HTTP requests work in release build (Ktor CIO)
- [ ] Verify logging works in release build (SLF4J)

Closes #64