### PR TITLE
Add Dependabot config and .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{kt,kts}]
+indent_size = 4
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` for automated weekly dependency updates:
  - Gradle dependencies (up to 5 open PRs)
  - GitHub Actions versions (up to 3 open PRs)
- Add `.editorconfig` for consistent formatting across editors:
  - UTF-8, LF line endings, 4-space indentation (2-space for YAML)
  - Trailing whitespace preserved in Markdown
- Skipped `settings.gradle.kts` centralized repos to avoid conflicts with existing `build.gradle.kts` repository declarations

## Test plan
- [ ] Verify Dependabot creates update PRs on next weekly scan
- [ ] Verify .editorconfig is picked up by IDEs

Closes #75