### PR TITLE
Replace variantType String with VariantType enum

### DIFF
--- a/src/commonMain/kotlin/catalog/CatalogCsvParser.kt
+++ b/src/commonMain/kotlin/catalog/CatalogCsvParser.kt
@@ -4,6 +4,7 @@ import kotlin.math.roundToInt
 import match.NameNormalizer
 import model.CardVariant
 import model.Catalog
+import model.VariantType
 
 /**
  * Parse the upstream CSV format used by the React inventory app (headers: SKU, Card Name, Set, Card Type, ...).
@@ -28,24 +29,12 @@ object CatalogCsvParser {
         "number" to "collectornumber"
     )
 
-    private val typePriceMapDefault = mapOf(
-        "Regular" to 2.2,
-        "Holo" to 3.0,
-        "Foil" to 3.5
-    )
+    private val typePriceMapDefault = VariantType.entries.associate {
+        it.displayName.lowercase() to it.defaultPriceInCents / 100.0
+    }
 
     private val htmlTagRegex = Regex("<[^>]+>")
     private val setCodeRegex = Regex("^[A-Z0-9]{2,5}$")
-
-    /** Canonicalize various representations of type into one of Regular/Holo/Foil */
-    private fun canonicalType(raw: String): String {
-        val t = raw.trim().lowercase()
-        return when {
-            "foil" in t -> "Foil"
-            "holo" in t -> "Holo"
-            else -> "Regular"
-        }
-    }
 
     private fun isTypeCell(raw: String): Boolean {
         val t = raw.lowercase()
@@ -84,7 +73,7 @@ object CatalogCsvParser {
             var name = aligned[idxName].trim()
             var set = aligned[idxSet].trim()
             val typeRaw = aligned[idxType].trim()
-            val type = canonicalType(typeRaw)
+            val type = VariantType.fromString(typeRaw)
             // Extract set code from name if present at end (e.g., 'An Offer You Can't Refuse SLP')
             var setCodeFromName: String? = null
             val setCodeMatch = Regex(" ([A-Z0-9]{2,5})$").find(name)
@@ -114,7 +103,7 @@ object CatalogCsvParser {
             if (sku.isBlank() || name.isBlank() || set.isBlank()) return@forEach
             val dollarsFromCell = if (idxPrice >= 0 && idxPrice < aligned.size) parsePriceCell(aligned[idxPrice]) else 0.0
             val priceDollars = if (dollarsFromCell > 0.0) dollarsFromCell else {
-                val key = type.lowercase()
+                val key = type.displayName.lowercase()
                 mapLower[key] ?: defaultsLower[key] ?: 0.0
             }
             val priceCents = (priceDollars * 100.0).roundToInt()

--- a/src/commonMain/kotlin/catalog/CatalogParser.kt
+++ b/src/commonMain/kotlin/catalog/CatalogParser.kt
@@ -4,6 +4,7 @@ import com.fleeksoft.ksoup.Ksoup
 import kotlin.math.roundToInt
 import model.CardVariant
 import model.Catalog
+import model.VariantType
 import match.NameNormalizer
 
 object CatalogParser {
@@ -21,19 +22,8 @@ object CatalogParser {
         "number" to "collectornumber"
     )
 
-    private val typePriceMap = mapOf(
-        "Regular" to 220,
-        "Holo" to 300,
-        "Foil" to 350
-    )
-
-    private fun canonicalType(raw: String): String {
-        val t = raw.trim().lowercase()
-        return when {
-            "foil" in t -> "Foil"
-            "holo" in t -> "Holo"
-            else -> "Regular"
-        }
+    private val typePriceMap = VariantType.entries.associate {
+        it to it.defaultPriceInCents
     }
 
     fun parse(html: String): Catalog {
@@ -64,7 +54,7 @@ object CatalogParser {
                 val name = extractValue("Card Name:") ?: return@mapNotNull null
                 val set = extractValue("Set:") ?: return@mapNotNull null
                 val typeRaw = extractValue("Card Type:") ?: return@mapNotNull null
-                val type = canonicalType(typeRaw)
+                val type = VariantType.fromString(typeRaw)
                 val priceRaw = extractValue("Base Price:") ?: ""
                 val collectorNumber = extractValue("Collector Number:")?.takeIf { it.isNotBlank() }
                 var priceCents = parsePrice(priceRaw)
@@ -107,7 +97,7 @@ object CatalogParser {
             val set = cells[setIdx].text().trim()
             val sku = cells[skuIdx].text().trim()
             val typeRaw = cells[typeIdx].text().trim()
-            val type = canonicalType(typeRaw)
+            val type = VariantType.fromString(typeRaw)
             val priceRaw = cells[priceIdx].text()
             val collectorNumber = if (collectorNumberIdx >= 0 && collectorNumberIdx < cells.size) {
                 cells[collectorNumberIdx].text().trim().takeIf { it.isNotBlank() }

--- a/src/commonMain/kotlin/catalog/KtorRemoteCatalogDataSource.kt
+++ b/src/commonMain/kotlin/catalog/KtorRemoteCatalogDataSource.kt
@@ -8,6 +8,7 @@ import io.ktor.http.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import model.Catalog
+import model.VariantType
 
 /**
  * Multiplatform remote catalog data source implemented with Ktor.
@@ -56,29 +57,14 @@ class KtorRemoteCatalogDataSource(private val client: HttpClient? = null) : Cata
     }
 
     private fun fillZeroPrices(catalog: Catalog): Catalog {
-        val centsMap = mapOf(
-            "Regular" to 220,
-            "Holo" to 300,
-            "Foil" to 350
-        )
         val updated = catalog.variants.map { v ->
-            val t = canonicalType(v.variantType)
             if (v.priceInCents <= 0) {
-                v.copy(priceInCents = centsMap[t] ?: 0, variantType = t)
+                v.copy(priceInCents = v.variantType.defaultPriceInCents)
             } else {
-                v.copy(variantType = t)
+                v
             }
         }
         return Catalog(updated)
-    }
-
-    private fun canonicalType(raw: String): String {
-        val t = raw.trim().lowercase()
-        return when {
-            "foil" in t -> "Foil"
-            "holo" in t -> "Holo"
-            else -> "Regular"
-        }
     }
 
     private suspend fun fetchAllCsvPages(client: HttpClient, log: (String) -> Unit): String {
@@ -149,17 +135,15 @@ class KtorRemoteCatalogDataSource(private val client: HttpClient? = null) : Cata
     private fun canonicalizePriceMap(map: Map<String, Double>): Map<String, Double> {
         val out = mutableMapOf<String, Double>()
         for ((k, v) in map) {
-            val t = canonicalType(k)
+            val t = VariantType.fromString(k).displayName
             val existing = out[t]
             if (existing == null || v > existing) out[t] = v
         }
         return out
     }
 
-    private fun jsPriceMapFallback(): Map<String, Double> = mapOf(
-        "Regular" to 2.2,
-        "Holo" to 3.0,
-        "Foil" to 3.5
-    )
+    private fun jsPriceMapFallback(): Map<String, Double> = VariantType.entries.associate {
+        it.displayName to it.defaultPriceInCents / 100.0
+    }
 }
 

--- a/src/commonMain/kotlin/database/Database.kt
+++ b/src/commonMain/kotlin/database/Database.kt
@@ -64,7 +64,7 @@ class Database(databaseDriverFactory: DatabaseDriverFactory) {
             nameNormalized = variant.nameNormalized,
             setCode = variant.setCode,
             sku = variant.sku,
-            variantType = variant.variantType,
+            variantType = variant.variantType.displayName,
             priceInCents = variant.priceInCents.toLong(),
             collectorNumber = variant.collectorNumber,
             imageUrl = variant.imageUrl
@@ -116,7 +116,7 @@ class Database(databaseDriverFactory: DatabaseDriverFactory) {
                     nameNormalized = variant.nameNormalized,
                     setCode = variant.setCode,
                     sku = variant.sku,
-                    variantType = variant.variantType,
+                    variantType = variant.variantType.displayName,
                     priceInCents = variant.priceInCents.toLong(),
                     collectorNumber = variant.collectorNumber,
                     imageUrl = variant.imageUrl

--- a/src/commonMain/kotlin/database/EntityMappers.kt
+++ b/src/commonMain/kotlin/database/EntityMappers.kt
@@ -1,6 +1,7 @@
 package database
 
 import model.SavedImport
+import model.VariantType
 
 /**
  * Extension functions to map between database entities and domain models.
@@ -27,7 +28,7 @@ fun CardVariantEntity.toDomain(): model.CardVariant {
         nameNormalized = this.nameNormalized,
         setCode = this.setCode,
         sku = this.sku,
-        variantType = this.variantType,
+        variantType = VariantType.fromString(this.variantType),
         priceInCents = this.priceInCents.toInt(),
         collectorNumber = this.collectorNumber,
         imageUrl = this.imageUrl

--- a/src/commonMain/kotlin/match/Matcher.kt
+++ b/src/commonMain/kotlin/match/Matcher.kt
@@ -80,7 +80,7 @@ object Matcher {
         val bySet = if (config.setPriority.isNotEmpty()) {
             filtered.sortedBy { idxOrEnd(config.setPriority, it.setCode) }
         } else filtered
-        val byVariant = bySet.sortedBy { idxOrEnd(config.variantPriority, it.variantType) }
+        val byVariant = bySet.sortedBy { idxOrEnd(config.variantPriority, it.variantType.displayName) }
         return byVariant.firstOrNull()
     }
 

--- a/src/commonMain/kotlin/model/Models.kt
+++ b/src/commonMain/kotlin/model/Models.kt
@@ -1,6 +1,23 @@
 package model
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+
+@Serializable
+enum class VariantType(val displayName: String, val defaultPriceInCents: Int) {
+    @SerialName("Regular") REGULAR("Regular", 220),
+    @SerialName("Foil") FOIL("Foil", 350),
+    @SerialName("Holo") HOLO("Holo", 300);
+
+    companion object {
+        fun fromString(value: String): VariantType = when {
+            value.equals("Foil", ignoreCase = true) -> FOIL
+            value.equals("Holo", ignoreCase = true) ||
+            value.contains("Holo", ignoreCase = true) -> HOLO
+            else -> REGULAR
+        }
+    }
+}
 
 @Serializable
 data class CardVariant(
@@ -8,7 +25,7 @@ data class CardVariant(
     val nameNormalized: String,
     val setCode: String,
     val sku: String,
-    val variantType: String, // Regular, Foil, Holo
+    val variantType: VariantType,
     val priceInCents: Int,
     val collectorNumber: String? = null,
     val imageUrl: String? = null
@@ -19,7 +36,12 @@ data class CardVariant(
 @Serializable
 data class Catalog(
     val variants: List<CardVariant>
-)
+) {
+    /** Lazy index for O(1) lookup by normalized name. */
+    val indexByName: Map<String, List<CardVariant>> by lazy {
+        variants.groupBy { it.nameNormalized }
+    }
+}
 
 enum class Section { MAIN, SIDEBOARD, COMMANDER }
 

--- a/src/commonMain/kotlin/ui/CatalogScreen.kt
+++ b/src/commonMain/kotlin/ui/CatalogScreen.kt
@@ -25,10 +25,10 @@ fun CatalogScreen(
     var query by remember { mutableStateOf("") }
     var variantFilter by remember { mutableStateOf("All") }
     val variants = catalog.variants
-    val variantTypes = remember { listOf("All") + variants.map { it.variantType }.distinct().sorted() }
+    val variantTypes = remember { listOf("All") + variants.map { it.variantType.displayName }.distinct().sorted() }
 
     val filtered = variants.filter { v ->
-        (variantFilter == "All" || v.variantType.equals(variantFilter, true)) &&
+        (variantFilter == "All" || v.variantType.displayName.equals(variantFilter, true)) &&
         (query.isBlank() || v.nameOriginal.contains(query, true) || v.setCode.contains(query, true) || v.sku.contains(query, true))
     }
 
@@ -129,7 +129,7 @@ fun CatalogScreen(
                                     }
                                 }
                                 Text(v.setCode, Modifier.weight(0.12f), style = MaterialTheme.typography.body2)
-                                Text(v.variantType, Modifier.weight(0.12f), style = MaterialTheme.typography.body2)
+                                Text(v.variantType.displayName, Modifier.weight(0.12f), style = MaterialTheme.typography.body2)
                                 Text(v.sku, Modifier.weight(0.18f), style = MaterialTheme.typography.body2)
                                 Text(
                                     formatPrice(v.priceInCents),

--- a/src/commonMain/kotlin/ui/ExportScreen.kt
+++ b/src/commonMain/kotlin/ui/ExportScreen.kt
@@ -107,7 +107,7 @@ fun ExportScreen(
                                     Text(first.nameOriginal, Modifier.weight(0.40f), style = MaterialTheme.typography.body2)
                                     Text(first.setCode, Modifier.weight(0.12f), style = MaterialTheme.typography.body2)
                                     Text(first.sku, Modifier.weight(0.20f), style = MaterialTheme.typography.body2)
-                                    Text(first.variantType, Modifier.weight(0.12f), style = MaterialTheme.typography.body2)
+                                    Text(first.variantType.displayName, Modifier.weight(0.12f), style = MaterialTheme.typography.body2)
                                     Text(qtyTotal.toString(), Modifier.weight(0.07f), style = MaterialTheme.typography.body2)
                                     Text(formatPrice(first.priceInCents), Modifier.weight(0.09f), style = MaterialTheme.typography.body2)
                                 }

--- a/src/commonMain/kotlin/ui/MatchesScreen.kt
+++ b/src/commonMain/kotlin/ui/MatchesScreen.kt
@@ -152,7 +152,7 @@ fun MatchesScreen(
                                 Text("${m.deckEntry.qty}", modifier = Modifier.width(40.dp), style = MaterialTheme.typography.body2)
                                 Text(m.deckEntry.cardName, modifier = Modifier.weight(0.35f), style = MaterialTheme.typography.body2)
                                 Text(v?.setCode ?: "-", modifier = Modifier.weight(0.10f), style = MaterialTheme.typography.body2)
-                                Text(v?.variantType ?: "-", modifier = Modifier.weight(0.12f), style = MaterialTheme.typography.body2)
+                                Text(v?.variantType?.displayName ?: "-", modifier = Modifier.weight(0.12f), style = MaterialTheme.typography.body2)
                                 Text(v?.sku ?: "-", modifier = Modifier.weight(0.18f), style = MaterialTheme.typography.body2)
 
                                 // Status badge

--- a/src/commonMain/kotlin/ui/ResolveScreen.kt
+++ b/src/commonMain/kotlin/ui/ResolveScreen.kt
@@ -157,7 +157,7 @@ fun ResolveScreen(
                                         style = MaterialTheme.typography.body2
                                     )
                                     Text(
-                                        variant.variantType,
+                                        variant.variantType.displayName,
                                         Modifier.width(100.dp),
                                         style = MaterialTheme.typography.body2
                                     )

--- a/src/commonMain/kotlin/ui/ResultsScreen.kt
+++ b/src/commonMain/kotlin/ui/ResultsScreen.kt
@@ -455,7 +455,7 @@ fun ResultsScreen(
                                 }
 
                                 Text(
-                                    variant?.variantType ?: "-",
+                                    variant?.variantType?.displayName ?: "-",
                                     Modifier.weight(0.15f),
                                     style = MaterialTheme.typography.body2
                                 )

--- a/src/desktopMain/kotlin/catalog/RemoteCatalogDataSource.kt
+++ b/src/desktopMain/kotlin/catalog/RemoteCatalogDataSource.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import model.Catalog
+import model.VariantType
 import platform.AppDirectories
 import java.nio.file.Files
 import java.nio.file.Path
@@ -25,27 +26,12 @@ class RemoteCatalogDataSource : CatalogDataSource {
     private val urlApi = "https://www.usmtgproxy.com/wp-content/uploads/single-card-list.csv"
     private val cacheFile: Path = AppDirectories.dataDir.resolve("catalog.json")
 
-    private fun canonicalType(raw: String): String {
-        val t = raw.trim().lowercase()
-        return when {
-            "foil" in t -> "Foil"
-            "holo" in t -> "Holo"
-            else -> "Regular"
-        }
-    }
-
     private fun fillZeroPrices(catalog: Catalog): Catalog {
-        val centsMap = mapOf(
-            "Regular" to 220,
-            "Holo" to 300,
-            "Foil" to 350
-        )
         val updated = catalog.variants.map { v ->
-            val t = canonicalType(v.variantType)
             if (v.priceInCents <= 0) {
-                v.copy(priceInCents = centsMap[t] ?: 0, variantType = t)
+                v.copy(priceInCents = v.variantType.defaultPriceInCents)
             } else {
-                v.copy(variantType = t)
+                v
             }
         }
         return Catalog(updated)
@@ -147,8 +133,7 @@ class RemoteCatalogDataSource : CatalogDataSource {
     private fun canonicalizePriceMap(map: Map<String, Double>): Map<String, Double> {
         val out = mutableMapOf<String, Double>()
         for ((k, v) in map) {
-            val t = canonicalType(k)
-            // prefer larger value if duplicates, but any non-zero is fine
+            val t = VariantType.fromString(k).displayName
             val existing = out[t]
             if (existing == null || v > existing) out[t] = v
         }
@@ -176,11 +161,9 @@ class RemoteCatalogDataSource : CatalogDataSource {
         return runCatching { CatalogParser.parse(html) }.onSuccess { /* no-op */ }.onFailure { log("Table parse failed: ${it.message}") }.getOrNull()?.let { fillZeroPrices(it) }
     }
 
-    private fun jsPriceMapFallback(): Map<String, Double> = mapOf(
-        "Regular" to 2.2,
-        "Holo" to 3.0,
-        "Foil" to 3.5
-    )
+    private fun jsPriceMapFallback(): Map<String, Double> = VariantType.entries.associate {
+        it.displayName to it.defaultPriceInCents / 100.0
+    }
 
     private fun fetchRaw(urlStr: String, log: (String) -> Unit): String {
         val url = URL(urlStr)

--- a/src/desktopMain/kotlin/export/CsvExporter.kt
+++ b/src/desktopMain/kotlin/export/CsvExporter.kt
@@ -1,6 +1,7 @@
 package export
 
 import model.DeckEntryMatch
+import model.VariantType
 import platform.AppDirectories
 import util.formatPrice
 import java.nio.file.Path
@@ -40,16 +41,16 @@ object CsvExporter {
                 first.nameOriginal,
                 first.setCode,
                 first.sku,
-                first.variantType,
+                first.variantType.displayName,
                 qtyTotal.toString(),
                 formatPrice(first.priceInCents)
             ).joinToString(",") { escapeCsvField(it) }
         }
         lines += ""
         // Summary
-        val regular = resolved.count { it.selectedVariant!!.variantType.equals("Regular", true) }
-        val holo = resolved.count { it.selectedVariant!!.variantType.equals("Holo", true) }
-        val foil = resolved.count { it.selectedVariant!!.variantType.equals("Foil", true) }
+        val regular = resolved.count { it.selectedVariant!!.variantType == VariantType.REGULAR }
+        val holo = resolved.count { it.selectedVariant!!.variantType == VariantType.HOLO }
+        val foil = resolved.count { it.selectedVariant!!.variantType == VariantType.FOIL }
         val totalCents = resolved.sumOf { it.selectedVariant!!.priceInCents * it.deckEntry.qty }
         lines += "${escapeCsvField("--- Summary ---")}"
         lines += "${escapeCsvField("Regular Cards")},${escapeCsvField(regular.toString())}"
@@ -82,7 +83,7 @@ object CsvExporter {
                     first.nameOriginal,
                     first.setCode,
                     first.sku,
-                    first.variantType,
+                    first.variantType.displayName,
                     qtyTotal.toString(),
                     formatPrice(first.priceInCents)
                 ).joinToString(",") { escapeCsvField(it) }
@@ -90,9 +91,9 @@ object CsvExporter {
 
             lines += ""
             lines += "${escapeCsvField("--- Summary ---")}"
-            val regular = resolved.count { it.selectedVariant!!.variantType.equals("Regular", true) }
-            val holo = resolved.count { it.selectedVariant!!.variantType.equals("Holo", true) }
-            val foil = resolved.count { it.selectedVariant!!.variantType.equals("Foil", true) }
+            val regular = resolved.count { it.selectedVariant!!.variantType == VariantType.REGULAR }
+            val holo = resolved.count { it.selectedVariant!!.variantType == VariantType.HOLO }
+            val foil = resolved.count { it.selectedVariant!!.variantType == VariantType.FOIL }
             val totalCents = resolved.sumOf { it.selectedVariant!!.priceInCents * it.deckEntry.qty }
             lines += "${escapeCsvField("Regular Cards")},${escapeCsvField(regular.toString())}"
             lines += "${escapeCsvField("Holo Cards")},${escapeCsvField(holo.toString())}"

--- a/src/desktopMain/kotlin/ui/DesktopResolveScreen.kt
+++ b/src/desktopMain/kotlin/ui/DesktopResolveScreen.kt
@@ -154,7 +154,7 @@ fun DesktopResolveScreen(
                                             selectedImageUrl = variant.imageUrl
                                             selectedCardName = variant.nameOriginal
                                             selectedSetCode = variant.setCode
-                                            selectedVariantType = variant.variantType
+                                            selectedVariantType = variant.variantType.displayName
                                         }
                                     )
                                     Spacer(Modifier.width(12.dp))
@@ -186,7 +186,7 @@ fun DesktopResolveScreen(
                                     
                                     // Variant Type
                                     Text(
-                                        variant.variantType,
+                                        variant.variantType.displayName,
                                         Modifier.width(100.dp),
                                         style = MaterialTheme.typography.body2
                                     )

--- a/src/iosMain/kotlin/app/IosScreens.kt
+++ b/src/iosMain/kotlin/app/IosScreens.kt
@@ -551,7 +551,7 @@ fun IosResolveScreen(
                                                         color = MaterialTheme.colors.onSurface.copy(alpha = 0.6f)
                                                     )
                                                     PixelBadge(
-                                                        text = variant.variantType,
+                                                        text = variant.variantType.displayName,
                                                         color = MaterialTheme.colors.primary
                                                     )
                                                 }
@@ -593,7 +593,7 @@ fun IosResolveScreen(
                                                 imageUrl = variant.imageUrl,
                                                 cardName = variant.nameOriginal,
                                                 setCode = variant.setCode,
-                                                variantType = variant.variantType,
+                                                variantType = variant.variantType.displayName,
                                                 onDismiss = { showImageModal = false }
                                             )
                                         }

--- a/src/iosMain/kotlin/platform/IosMviPlatformServices.kt
+++ b/src/iosMain/kotlin/platform/IosMviPlatformServices.kt
@@ -149,12 +149,12 @@ class IosMviPlatformServices(
                 val priceCents = variant.priceInCents
                 val priceStr = platform.formatDecimal(priceCents / 100.0, 2)
 
-                sb.appendLine("${variant.nameOriginal},${variant.setCode},${variant.sku},${variant.variantType},$qty,$priceStr")
+                sb.appendLine("${variant.nameOriginal},${variant.setCode},${variant.sku},${variant.variantType.displayName},$qty,$priceStr")
 
                 when (variant.variantType) {
-                    "Regular" -> regularCount += qty
-                    "Holo" -> holoCount += qty
-                    "Foil" -> foilCount += qty
+                    model.VariantType.REGULAR -> regularCount += qty
+                    model.VariantType.HOLO -> holoCount += qty
+                    model.VariantType.FOIL -> foilCount += qty
                 }
                 totalPriceCents += priceCents * qty
             }


### PR DESCRIPTION
## Summary
- Create `VariantType` enum with `REGULAR`, `FOIL`, `HOLO` values, each carrying `displayName` and `defaultPriceInCents`
- Change `CardVariant.variantType` from `String` to `VariantType`
- Remove all four `canonicalType()` functions, replaced by `VariantType.fromString()`
- Replace all hardcoded default price constants (220/300/350) with `VariantType.X.defaultPriceInCents`
- Convert at DB boundary: store as `displayName` string, read back via `fromString()`
- Update 17 files across parsers, database, matcher, exporter, and UI layers

## Test plan
- [ ] `./gradlew build` compiles
- [ ] Load catalog — prices display correctly
- [ ] Match cards — variant type filtering works
- [ ] Export CSV — variant types show as "Regular"/"Foil"/"Holo"
- [ ] Existing DB data loads correctly (backward compatible)

Closes #73