### PR TITLE
Fix broken build: add missing Catalog.indexByName property

### DIFF
--- a/src/commonMain/kotlin/model/Models.kt
+++ b/src/commonMain/kotlin/model/Models.kt
@@ -19,7 +19,11 @@ data class CardVariant(
 @Serializable
 data class Catalog(
     val variants: List<CardVariant>
-)
+) {
+    val indexByName: Map<String, List<CardVariant>> by lazy {
+        variants.groupBy { it.nameNormalized }
+    }
+}
 
 enum class Section { MAIN, SIDEBOARD, COMMANDER }
 


### PR DESCRIPTION
## Summary
- PR #102 updated `Matcher.kt` to use `catalog.indexByName` for O(1) lookups but the lazy property was never added to the `Catalog` data class in `Models.kt`
- This breaks compilation on `main` and causes all Dependabot PRs to fail CI

## Test plan
- [x] `compileCommonMainKotlinMetadata` passes
- [x] `compileKotlinDesktop` passes