### PR TITLE
Add Unicode normalization, alternate names, and fuzzy blocklist

### DIFF
--- a/src/commonMain/kotlin/match/Matcher.kt
+++ b/src/commonMain/kotlin/match/Matcher.kt
@@ -14,6 +14,33 @@ object Matcher {
         val fuzzyEnabled: Boolean
     )
 
+    /** Secret Lair and promotional alternate names mapped to their canonical card names. */
+    private val ALTERNATE_NAMES = mapOf(
+        "Calliope's Song" to "Seething Song",
+        "Earth's Mightiest Emblem" to "Arcane Signet",
+        "Fangorn Forest" to "Yavimaya, Cradle of Growth",
+        "Hope's Aero Magic" to "Cyclonic Rift",
+        "La abundancia de Yucahú" to "Sylvan Library",
+        "La abundancia de Yucahu" to "Sylvan Library",
+        "Power Sneakers" to "Lightning Greaves",
+        "Storm's Will" to "Jeska's Will",
+    )
+
+    /** Pre-normalized version of [ALTERNATE_NAMES] for case/accent-insensitive lookup. */
+    private val ALTERNATE_NAMES_NORMALIZED: Map<String, String> =
+        ALTERNATE_NAMES.entries.associate { (k, v) ->
+            NameNormalizer.normalize(k) to v
+        }
+
+    /**
+     * Pairs of normalized names that are within Levenshtein distance but should
+     * never match each other.
+     */
+    private val FUZZY_BLOCKLIST: Map<String, Set<String>> = mapOf(
+        "electrodominance" to setOf("necrodominance"),
+        "necrodominance" to setOf("electrodominance"),
+    )
+
     fun matchAll(entries: List<DeckEntry>, catalog: Catalog, config: MatchConfig): List<DeckEntryMatch> {
         return entries.map { matchEntry(it, catalog, config) }
     }
@@ -67,9 +94,26 @@ object Matcher {
                 catalog.variants.filter { it.setCode.equals(entry.setCodeHint, true) }
             } else catalog.variants
             val fuzzyCandidates = fuzzy(normalized, Catalog(fuzzyPool))
-            return if (fuzzyCandidates.isEmpty()) DeckEntryMatch(entry, MatchStatus.NOT_FOUND)
-            else DeckEntryMatch(entry, MatchStatus.AMBIGUOUS, null, fuzzyCandidates)
+            if (fuzzyCandidates.isNotEmpty()) {
+                return DeckEntryMatch(entry, MatchStatus.AMBIGUOUS, null, fuzzyCandidates)
+            }
         }
+
+        // Pass 5 – Alternate name retry: if the card name has a known alternate,
+        // re-run matching with the canonical name
+        val alternateName = ALTERNATE_NAMES[entry.cardName]
+            ?: ALTERNATE_NAMES_NORMALIZED[normalized]
+        if (alternateName != null) {
+            val aliasEntry = entry.copy(cardName = alternateName)
+            val aliasResult = matchEntry(aliasEntry, catalog, config)
+            if (aliasResult.status != MatchStatus.NOT_FOUND) {
+                return aliasResult.copy(
+                    deckEntry = entry,
+                    notes = "Matched via alternate name: ${entry.cardName} -> $alternateName"
+                )
+            }
+        }
+
         return DeckEntryMatch(entry, MatchStatus.NOT_FOUND)
     }
 
@@ -90,8 +134,10 @@ object Matcher {
     }
 
     private fun fuzzy(targetNorm: String, catalog: Catalog): List<MatchCandidate> {
+        val blocked = FUZZY_BLOCKLIST[targetNorm].orEmpty()
         val results = mutableListOf<MatchCandidate>()
         for (variant in catalog.variants) {
+            if (variant.nameNormalized in blocked) continue
             val dist = Levenshtein.distance(targetNorm, variant.nameNormalized)
             val threshold = if (targetNorm.length <= 15) 2 else 3
             if (dist <= threshold) {

--- a/src/commonMain/kotlin/match/NameNormalizer.kt
+++ b/src/commonMain/kotlin/match/NameNormalizer.kt
@@ -1,6 +1,6 @@
 package match
 
-// Multiplatform-safe name normalization (simplified, no Unicode decomposition)
+// Multiplatform-safe name normalization with Unicode diacritic stripping
 object NameNormalizer {
     private val PUNCTUATION = "[,'`\u2019]".toRegex()
     private val DASHES = "[-\u2013\u2014]".toRegex()
@@ -9,7 +9,9 @@ object NameNormalizer {
     private val WHITESPACE = "\\s+".toRegex()
 
     fun normalize(raw: String): String {
-        val lower = raw.lowercase()
+        // Strip diacritics first so accented characters become ASCII base letters
+        val stripped = stripDiacritics(raw)
+        val lower = stripped.lowercase()
         val replaced = lower
             .replace(PUNCTUATION, "")
             .replace(DASHES, " ")

--- a/src/commonMain/kotlin/match/UnicodeUtils.kt
+++ b/src/commonMain/kotlin/match/UnicodeUtils.kt
@@ -1,0 +1,11 @@
+package match
+
+/**
+ * Strip diacritical marks from the input string so that accented characters
+ * compare equal to their ASCII base letters.
+ *
+ * Platform-specific implementations use the best available API:
+ * - JVM: [java.text.Normalizer] NFD decomposition + regex strip
+ * - iOS/Native: manual replacement map covering MTG card names
+ */
+expect fun stripDiacritics(input: String): String

--- a/src/commonTest/kotlin/match/MatcherTest.kt
+++ b/src/commonTest/kotlin/match/MatcherTest.kt
@@ -1,0 +1,100 @@
+package match
+
+import model.CardVariant
+import model.Catalog
+import model.DeckEntry
+import model.MatchStatus
+import model.Section
+import model.VariantType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class MatcherTest {
+
+    private val defaultConfig = Matcher.MatchConfig(
+        variantPriority = listOf("Regular"),
+        setPriority = emptyList(),
+        fuzzyEnabled = true
+    )
+
+    private fun variant(name: String, set: String = "TST", sku: String = "sku-$name"): CardVariant =
+        CardVariant(
+            nameOriginal = name,
+            nameNormalized = NameNormalizer.normalize(name),
+            setCode = set,
+            sku = sku,
+            variantType = VariantType.REGULAR,
+            priceInCents = 100
+        )
+
+    private fun entry(name: String, id: String = "e-$name"): DeckEntry =
+        DeckEntry(
+            id = id,
+            originalLine = "1 $name",
+            qty = 1,
+            cardName = name,
+            section = Section.MAIN,
+            include = true
+        )
+
+    @Test
+    fun alternateNameMatchesCanonicalCard() {
+        val catalog = Catalog(listOf(variant("Seething Song")))
+        val results = Matcher.matchAll(listOf(entry("Calliope's Song")), catalog, defaultConfig)
+
+        assertEquals(1, results.size)
+        val result = results.first()
+        assertEquals(MatchStatus.AUTO_MATCHED, result.status)
+        assertEquals("Seething Song", result.selectedVariant?.nameOriginal)
+        assertTrue(result.notes.contains("alternate name"), "Expected notes to mention alternate name")
+    }
+
+    @Test
+    fun alternateNameWithAccentMatchesCanonicalCard() {
+        val catalog = Catalog(listOf(variant("Sylvan Library")))
+        val results = Matcher.matchAll(
+            listOf(entry("La abundancia de Yucah\u00fa")),
+            catalog,
+            defaultConfig
+        )
+
+        assertEquals(1, results.size)
+        val result = results.first()
+        assertEquals(MatchStatus.AUTO_MATCHED, result.status)
+        assertEquals("Sylvan Library", result.selectedVariant?.nameOriginal)
+    }
+
+    @Test
+    fun fuzzyBlocklistPreventsElectrodominanceMatchingNecrodominance() {
+        val catalog = Catalog(listOf(variant("Necrodominance")))
+        val results = Matcher.matchAll(listOf(entry("Electrodominance")), catalog, defaultConfig)
+
+        assertEquals(1, results.size)
+        val result = results.first()
+        // Should NOT match Necrodominance due to blocklist
+        assertEquals(MatchStatus.NOT_FOUND, result.status)
+    }
+
+    @Test
+    fun fuzzyBlocklistPreventsNecrodominanceMatchingElectrodominance() {
+        val catalog = Catalog(listOf(variant("Electrodominance")))
+        val results = Matcher.matchAll(listOf(entry("Necrodominance")), catalog, defaultConfig)
+
+        assertEquals(1, results.size)
+        val result = results.first()
+        assertEquals(MatchStatus.NOT_FOUND, result.status)
+    }
+
+    @Test
+    fun exactMatchStillWorksWithBlocklistedCard() {
+        // The blocklist should only affect fuzzy matching, not exact matches
+        val catalog = Catalog(listOf(variant("Necrodominance")))
+        val results = Matcher.matchAll(listOf(entry("Necrodominance")), catalog, defaultConfig)
+
+        assertEquals(1, results.size)
+        val result = results.first()
+        assertEquals(MatchStatus.AUTO_MATCHED, result.status)
+        assertEquals("Necrodominance", result.selectedVariant?.nameOriginal)
+    }
+}

--- a/src/commonTest/kotlin/match/NameNormalizerTest.kt
+++ b/src/commonTest/kotlin/match/NameNormalizerTest.kt
@@ -65,4 +65,25 @@ class NameNormalizerTest {
     fun alreadyNormalizedStringIsUnchanged() {
         assertEquals("lightning bolt", NameNormalizer.normalize("lightning bolt"))
     }
+
+    @Test
+    fun stripsDiacriticsFromAccentedU() {
+        // Yucahú → yucahu (accent on ú stripped)
+        val result = NameNormalizer.normalize("Yucahú")
+        assertEquals("yucahu", result)
+    }
+
+    @Test
+    fun stripsDiacriticsFromSeance() {
+        // Séance → seance (accent on é stripped, non-alnum removed)
+        val result = NameNormalizer.normalize("Séance")
+        assertEquals("seance", result)
+    }
+
+    @Test
+    fun stripsDiacriticsFromMultipleAccents() {
+        // Covers ñ and á together
+        val result = NameNormalizer.normalize("Año")
+        assertEquals("ano", result)
+    }
 }

--- a/src/desktopMain/kotlin/match/UnicodeUtils.kt
+++ b/src/desktopMain/kotlin/match/UnicodeUtils.kt
@@ -1,0 +1,12 @@
+package match
+
+import java.text.Normalizer
+
+/**
+ * JVM implementation: use NFD decomposition to split base characters from
+ * combining marks, then strip all combining (Mn category) characters.
+ */
+actual fun stripDiacritics(input: String): String {
+    val decomposed = Normalizer.normalize(input, Normalizer.Form.NFD)
+    return decomposed.replace("\\p{Mn}".toRegex(), "")
+}

--- a/src/iosMain/kotlin/match/UnicodeUtils.kt
+++ b/src/iosMain/kotlin/match/UnicodeUtils.kt
@@ -1,0 +1,70 @@
+package match
+
+/**
+ * iOS/Native implementation: manual replacement of common accented characters
+ * found in Magic: The Gathering card names. This avoids reliance on JVM-only
+ * regex Unicode categories (\p{Mn}) which are unavailable on Kotlin/Native.
+ */
+actual fun stripDiacritics(input: String): String {
+    val sb = StringBuilder(input.length)
+    for (ch in input) {
+        sb.append(DIACRITIC_MAP.getOrDefault(ch, ch))
+    }
+    return sb.toString()
+}
+
+private val DIACRITIC_MAP: Map<Char, Char> = mapOf(
+    '\u00C0' to 'A', // À
+    '\u00C1' to 'A', // Á
+    '\u00C2' to 'A', // Â
+    '\u00C3' to 'A', // Ã
+    '\u00C4' to 'A', // Ä
+    '\u00C5' to 'A', // Å
+    '\u00C7' to 'C', // Ç
+    '\u00C8' to 'E', // È
+    '\u00C9' to 'E', // É
+    '\u00CA' to 'E', // Ê
+    '\u00CB' to 'E', // Ë
+    '\u00CC' to 'I', // Ì
+    '\u00CD' to 'I', // Í
+    '\u00CE' to 'I', // Î
+    '\u00CF' to 'I', // Ï
+    '\u00D1' to 'N', // Ñ
+    '\u00D2' to 'O', // Ò
+    '\u00D3' to 'O', // Ó
+    '\u00D4' to 'O', // Ô
+    '\u00D5' to 'O', // Õ
+    '\u00D6' to 'O', // Ö
+    '\u00D9' to 'U', // Ù
+    '\u00DA' to 'U', // Ú
+    '\u00DB' to 'U', // Û
+    '\u00DC' to 'U', // Ü
+    '\u00DD' to 'Y', // Ý
+    '\u00E0' to 'a', // à
+    '\u00E1' to 'a', // á
+    '\u00E2' to 'a', // â
+    '\u00E3' to 'a', // ã
+    '\u00E4' to 'a', // ä
+    '\u00E5' to 'a', // å
+    '\u00E7' to 'c', // ç
+    '\u00E8' to 'e', // è
+    '\u00E9' to 'e', // é
+    '\u00EA' to 'e', // ê
+    '\u00EB' to 'e', // ë
+    '\u00EC' to 'i', // ì
+    '\u00ED' to 'i', // í
+    '\u00EE' to 'i', // î
+    '\u00EF' to 'i', // ï
+    '\u00F1' to 'n', // ñ
+    '\u00F2' to 'o', // ò
+    '\u00F3' to 'o', // ó
+    '\u00F4' to 'o', // ô
+    '\u00F5' to 'o', // õ
+    '\u00F6' to 'o', // ö
+    '\u00F9' to 'u', // ù
+    '\u00FA' to 'u', // ú
+    '\u00FB' to 'u', // û
+    '\u00FC' to 'u', // ü
+    '\u00FD' to 'y', // ý
+    '\u00FF' to 'y', // ÿ
+)


### PR DESCRIPTION
## Summary
Three matching improvements ported from mtg-order:

- **Unicode NFD decomposition** (#94): Strips diacritics so "Yucahú" matches "Yucahu", "Séance" matches "Seance". Uses `java.text.Normalizer` on JVM, manual char map on iOS (expect/actual pattern)
- **Secret Lair alternate names** (#95): 8-entry mapping dict for promotional reskins (e.g., "Calliope's Song" → "Seething Song"). Added as pass 5 after fuzzy, before NOT_FOUND
- **Fuzzy match blocklist** (#96): Prevents known false positives like electrodominance ↔ necrodominance

8 new tests (5 Matcher + 3 NameNormalizer), all passing. Detekt clean.

## Test plan
- [ ] `./gradlew build` compiles
- [ ] `./gradlew allTests` passes (43 tests)
- [ ] Match "Calliope's Song" against a catalog with "Seething Song" — should match
- [ ] Match a card with diacritics — should normalize and match

Closes #94
Closes #95
Closes #96