### PR TITLE
Add Bootleg Mage CatalogSource adapter

### DIFF
--- a/detekt-baseline-commonMainSourceSet.xml
+++ b/detekt-baseline-commonMainSourceSet.xml
@@ -32,9 +32,15 @@
     <ID>LongMethod:ResultsScreen.kt:@Composable fun ResultsScreen</ID>
     <ID>LongMethod:StepperComponent.kt:@Composable fun PixelStepNode</ID>
     <ID>LongMethod:StepperComponent.kt:@Composable fun RowScope.PixelStepConnector</ID>
+    <ID>LoopWithTooManyJumpStatements:BootlegMageCatalogSource.kt:BootlegMageCatalogSource$for</ID>
+    <ID>LoopWithTooManyJumpStatements:BootlegMageCatalogSource.kt:BootlegMageCatalogSource$while</ID>
     <ID>LoopWithTooManyJumpStatements:DecklistParser.kt:DecklistParser$for</ID>
     <ID>LoopWithTooManyJumpStatements:KtorRemoteCatalogDataSource.kt:KtorRemoteCatalogDataSource$while</ID>
     <ID>LoopWithTooManyJumpStatements:MultiCatalogMatcher.kt:MultiCatalogMatcher$for</ID>
+    <ID>MagicNumber:BootlegMageCatalogSource.kt:BootlegMageCatalogSource$100</ID>
+    <ID>MagicNumber:BootlegMageCatalogSource.kt:BootlegMageCatalogSource$3</ID>
+    <ID>MagicNumber:BootlegMageCatalogSource.kt:BootlegMageCatalogSource$401</ID>
+    <ID>MagicNumber:BootlegMageCatalogSource.kt:BootlegMageCatalogSource$403</ID>
     <ID>MagicNumber:CardVariantQueries.kt:CardVariantQueries$10</ID>
     <ID>MagicNumber:CardVariantQueries.kt:CardVariantQueries$184_426_222</ID>
     <ID>MagicNumber:CardVariantQueries.kt:CardVariantQueries$1_386_511_848</ID>
@@ -314,7 +320,9 @@
     <ID>ReturnCount:CatalogParser.kt:CatalogParser$fun parse: Catalog</ID>
     <ID>ReturnCount:Levenshtein.kt:Levenshtein$fun distance: Int</ID>
     <ID>ReturnCount:Matcher.kt:Matcher$private fun matchEntry: DeckEntryMatch</ID>
+    <ID>SwallowedException:BootlegMageCatalogSource.kt:BootlegMageCatalogSource$e: Exception</ID>
     <ID>SwallowedException:ScryfallApi.kt:ScryfallApi$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:BootlegMageCatalogSource.kt:BootlegMageCatalogSource$e: Exception</ID>
     <ID>TooGenericExceptionCaught:CatalogUseCase.kt:CatalogUseCase$e: Exception</ID>
     <ID>TooGenericExceptionCaught:ImportExportUseCase.kt:ImportExportUseCase$e: Exception</ID>
     <ID>TooGenericExceptionCaught:KtorRemoteCatalogDataSource.kt:KtorRemoteCatalogDataSource$e: Exception</ID>

--- a/src/commonMain/kotlin/catalog/BootlegMageCatalogSource.kt
+++ b/src/commonMain/kotlin/catalog/BootlegMageCatalogSource.kt
@@ -1,0 +1,317 @@
+package catalog
+
+import com.fleeksoft.ksoup.Ksoup
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logging
+import io.ktor.client.request.accept
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.parameter
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.isSuccess
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import match.NameNormalizer
+import model.CardVariant
+import model.OrderItem
+import model.Seller
+import model.VariantType
+import kotlin.math.roundToInt
+
+/**
+ * Catalog source for Bootleg Mage (bootlegmage.com).
+ *
+ * Fetching strategy:
+ *  1. Try WooCommerce REST API (`/wp-json/wc/v3/products`) for structured JSON.
+ *  2. If blocked (401/403) or unavailable, fall back to HTML scraping with Ksoup.
+ *
+ * Product names follow the format "Card Name - SET - Variant"
+ * (e.g., "Lightning Bolt - M11 - Foil").
+ */
+class BootlegMageCatalogSource(
+    private val client: HttpClient? = null,
+) : CatalogSource {
+
+    override val seller = Seller.BOOTLEG_MAGE
+
+    private companion object {
+        const val BASE_URL = "https://bootlegmage.com"
+        const val WC_API_PRODUCTS = "$BASE_URL/wp-json/wc/v3/products"
+        const val SHOP_URL = "$BASE_URL/shop/"
+        const val CHECKOUT_URL = "$BASE_URL/deck-import/"
+        const val PER_PAGE = 100
+        const val MAX_PAGES = 20
+    }
+
+    override suspend fun fetchCatalog(log: (String) -> Unit): List<CardVariant> =
+        withContext(Dispatchers.Default) {
+            val http = client ?: defaultClient()
+            // Strategy 1: WooCommerce REST API
+            val apiVariants = tryWooCommerceApi(http, log)
+            if (apiVariants.isNotEmpty()) return@withContext apiVariants
+
+            // Strategy 2: HTML scraping fallback
+            val htmlVariants = tryHtmlScrape(http, log)
+            if (htmlVariants.isNotEmpty()) return@withContext htmlVariants
+
+            log("Bootleg Mage: no products found via API or HTML")
+            emptyList()
+        }
+
+    override suspend fun search(cardName: String): List<CardVariant> {
+        val http = client ?: defaultClient()
+        return try {
+            // Try WooCommerce search endpoint
+            val response = http.get(WC_API_PRODUCTS) {
+                parameter("search", cardName)
+                parameter("per_page", PER_PAGE.toString())
+                header(HttpHeaders.UserAgent, "MtgPirate/1.0 (KMP)")
+                accept(ContentType.Application.Json)
+            }
+            if (!response.status.isSuccess()) return emptyList()
+            parseWooCommerceJson(response.bodyAsText())
+        } catch (e: Exception) {
+            // API search unavailable — fall back to HTML search
+            tryHtmlSearch(http, cardName)
+        }
+    }
+
+    override fun checkoutUrl(items: List<OrderItem>): String = CHECKOUT_URL
+
+    override fun formatForExport(items: List<OrderItem>): String {
+        // Bootleg Mage deck import format: "qty CardName" per line
+        return items.joinToString("\n") { "${it.qty} ${it.variant.nameOriginal}" }
+    }
+
+    // ---- WooCommerce REST API ----
+
+    private suspend fun tryWooCommerceApi(
+        http: HttpClient,
+        log: (String) -> Unit,
+    ): List<CardVariant> {
+        val allVariants = mutableListOf<CardVariant>()
+        var page = 1
+        try {
+            while (page <= MAX_PAGES) {
+                log("Bootleg Mage: fetching WooCommerce API page $page")
+                val response = http.get(WC_API_PRODUCTS) {
+                    parameter("per_page", PER_PAGE.toString())
+                    parameter("page", page.toString())
+                    header(HttpHeaders.UserAgent, "MtgPirate/1.0 (KMP)")
+                    accept(ContentType.Application.Json)
+                }
+                val status = response.status.value
+                if (status == 401 || status == 403) {
+                    log("Bootleg Mage: WooCommerce API returned $status — falling back to HTML")
+                    return emptyList()
+                }
+                if (!response.status.isSuccess()) {
+                    log("Bootleg Mage: WooCommerce API returned $status")
+                    break
+                }
+                val body = response.bodyAsText()
+                val variants = parseWooCommerceJson(body)
+                if (variants.isEmpty()) break
+                allVariants.addAll(variants)
+                log("Bootleg Mage: page $page yielded ${variants.size} variants (total ${allVariants.size})")
+                if (variants.size < PER_PAGE) break
+                page++
+            }
+        } catch (e: Exception) {
+            log("Bootleg Mage: WooCommerce API error — ${e.message}")
+            return emptyList()
+        }
+        return allVariants
+    }
+
+    /**
+     * Parse WooCommerce JSON product array into [CardVariant] list.
+     * Expected JSON: `[{"id":1,"name":"Card - SET - Variant","price":"2.20",
+     *   "permalink":"...","images":[{"src":"..."}]}, ...]`
+     */
+    internal fun parseWooCommerceJson(json: String): List<CardVariant> {
+        if (json.isBlank()) return emptyList()
+        val variants = mutableListOf<CardVariant>()
+        try {
+            val parser = Json { ignoreUnknownKeys = true }
+            val array = parser.parseToJsonElement(json).jsonArray
+            for (element in array) {
+                val obj = element.jsonObject
+                val rawName = obj["name"]?.jsonPrimitive?.contentOrNull ?: continue
+                val priceStr = obj["price"]?.jsonPrimitive?.contentOrNull ?: "0"
+                val permalink = obj["permalink"]?.jsonPrimitive?.contentOrNull
+                val imageUrl = obj["images"]?.jsonArray?.firstOrNull()
+                    ?.jsonObject?.get("src")?.jsonPrimitive?.contentOrNull
+                val id = obj["id"]?.jsonPrimitive?.contentOrNull ?: "0"
+
+                val parsed = parseProductName(rawName) ?: continue
+                val priceCents = parsePriceToCents(priceStr)
+
+                variants.add(
+                    CardVariant(
+                        nameOriginal = parsed.cardName,
+                        nameNormalized = NameNormalizer.normalize(parsed.cardName),
+                        setCode = parsed.setCode,
+                        sku = "BM-$id",
+                        variantType = parsed.variantType,
+                        priceInCents = if (priceCents > 0) priceCents else parsed.variantType.defaultPriceInCents,
+                        imageUrl = imageUrl,
+                        seller = Seller.BOOTLEG_MAGE,
+                        purchaseUri = permalink,
+                    )
+                )
+            }
+        } catch (_: Exception) {
+            // Malformed JSON — return whatever we parsed so far
+        }
+        return variants
+    }
+
+    // ---- HTML scraping fallback ----
+
+    private suspend fun tryHtmlScrape(
+        http: HttpClient,
+        log: (String) -> Unit,
+    ): List<CardVariant> {
+        return try {
+            log("Bootleg Mage: fetching shop HTML")
+            val response = http.get(SHOP_URL) {
+                header(HttpHeaders.UserAgent, "MtgPirate/1.0 (KMP)")
+                accept(ContentType.Text.Html)
+            }
+            if (!response.status.isSuccess()) {
+                log("Bootleg Mage: shop HTML returned ${response.status.value}")
+                return emptyList()
+            }
+            parseShopHtml(response.bodyAsText())
+        } catch (e: Exception) {
+            log("Bootleg Mage: HTML scraping failed — ${e.message}")
+            emptyList()
+        }
+    }
+
+    private suspend fun tryHtmlSearch(
+        http: HttpClient,
+        cardName: String,
+    ): List<CardVariant> {
+        return try {
+            val response = http.get(SHOP_URL) {
+                parameter("s", cardName)
+                parameter("post_type", "product")
+                header(HttpHeaders.UserAgent, "MtgPirate/1.0 (KMP)")
+                accept(ContentType.Text.Html)
+            }
+            if (!response.status.isSuccess()) return emptyList()
+            parseShopHtml(response.bodyAsText())
+        } catch (_: Exception) {
+            emptyList()
+        }
+    }
+
+    /**
+     * Parse WooCommerce shop HTML page into [CardVariant] list.
+     * Looks for `.product` elements with title and price.
+     */
+    internal fun parseShopHtml(html: String): List<CardVariant> {
+        if (html.isBlank()) return emptyList()
+        val doc = Ksoup.parse(html)
+        val variants = mutableListOf<CardVariant>()
+
+        // WooCommerce product listing: <li class="product"> or <div class="product">
+        val products = doc.select("li.product, div.product")
+        var index = 0
+        for (product in products) {
+            val titleEl = product.selectFirst(".woocommerce-loop-product__title")
+                ?: product.selectFirst("h2")
+            val rawName = titleEl?.text()?.trim() ?: continue
+
+            val priceEl = product.selectFirst(".woocommerce-Price-amount")
+                ?: product.selectFirst(".price")
+            val priceText = priceEl?.text() ?: "0"
+
+            val link = product.selectFirst("a")?.attr("href")
+            val imageUrl = product.selectFirst("img")?.attr("src")
+
+            val parsed = parseProductName(rawName) ?: continue
+            val priceCents = parsePriceToCents(priceText)
+            index++
+
+            variants.add(
+                CardVariant(
+                    nameOriginal = parsed.cardName,
+                    nameNormalized = NameNormalizer.normalize(parsed.cardName),
+                    setCode = parsed.setCode,
+                    sku = "BM-HTML-$index",
+                    variantType = parsed.variantType,
+                    priceInCents = if (priceCents > 0) priceCents else parsed.variantType.defaultPriceInCents,
+                    imageUrl = imageUrl,
+                    seller = Seller.BOOTLEG_MAGE,
+                    purchaseUri = link,
+                )
+            )
+        }
+        return variants
+    }
+
+    // ---- Shared parsing helpers ----
+
+    /** Parsed components from a Bootleg Mage product name. */
+    internal data class ParsedProduct(
+        val cardName: String,
+        val setCode: String,
+        val variantType: VariantType,
+    )
+
+    /**
+     * Parse "Card Name - SET - Variant" format.
+     * Falls back gracefully when parts are missing:
+     *  - "Card Name - SET" -> Regular variant
+     *  - "Card Name" -> set "UNK", Regular variant
+     */
+    internal fun parseProductName(rawName: String): ParsedProduct? {
+        val trimmed = rawName.trim()
+        if (trimmed.isBlank()) return null
+
+        val parts = trimmed.split(" - ").map { it.trim() }
+        return when {
+            parts.size >= 3 -> ParsedProduct(
+                cardName = parts.dropLast(2).joinToString(" - "),
+                setCode = parts[parts.size - 2].uppercase(),
+                variantType = VariantType.fromString(parts.last()),
+            )
+            parts.size == 2 -> ParsedProduct(
+                cardName = parts[0],
+                setCode = parts[1].uppercase(),
+                variantType = VariantType.REGULAR,
+            )
+            else -> ParsedProduct(
+                cardName = trimmed,
+                setCode = "UNK",
+                variantType = VariantType.REGULAR,
+            )
+        }
+    }
+
+    private fun parsePriceToCents(raw: String): Int {
+        val cleaned = raw.replace("[^0-9.]".toRegex(), "")
+        if (cleaned.isBlank()) return 0
+        return try {
+            (cleaned.toDouble() * 100).roundToInt()
+        } catch (_: NumberFormatException) {
+            0
+        }
+    }
+
+    private fun defaultClient(): HttpClient = HttpClient {
+        install(Logging) { level = LogLevel.INFO }
+        expectSuccess = false // We handle status codes manually
+    }
+}

--- a/src/commonTest/kotlin/catalog/BootlegMageCatalogSourceTest.kt
+++ b/src/commonTest/kotlin/catalog/BootlegMageCatalogSourceTest.kt
@@ -1,0 +1,365 @@
+package catalog
+
+import model.OrderItem
+import model.Seller
+import model.VariantType
+import model.CardVariant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class BootlegMageCatalogSourceTest {
+
+    private val source = BootlegMageCatalogSource()
+
+    // ---- seller property ----
+
+    @Test
+    fun `seller is BOOTLEG_MAGE`() {
+        assertEquals(Seller.BOOTLEG_MAGE, source.seller)
+    }
+
+    // ---- checkoutUrl ----
+
+    @Test
+    fun `checkoutUrl returns deck import URL`() {
+        val url = source.checkoutUrl(emptyList())
+        assertEquals("https://bootlegmage.com/deck-import/", url)
+    }
+
+    @Test
+    fun `checkoutUrl returns same URL regardless of items`() {
+        val items = listOf(sampleOrderItem())
+        val url = source.checkoutUrl(items)
+        assertEquals("https://bootlegmage.com/deck-import/", url)
+    }
+
+    // ---- formatForExport ----
+
+    @Test
+    fun `formatForExport produces qty cardName lines`() {
+        val items = listOf(
+            OrderItem(
+                variant = CardVariant(
+                    nameOriginal = "Lightning Bolt",
+                    nameNormalized = "lightning bolt",
+                    setCode = "M11",
+                    sku = "BM-1",
+                    variantType = VariantType.REGULAR,
+                    priceInCents = 220,
+                    seller = Seller.BOOTLEG_MAGE,
+                ),
+                qty = 4,
+                isProxy = true,
+            ),
+            OrderItem(
+                variant = CardVariant(
+                    nameOriginal = "Counterspell",
+                    nameNormalized = "counterspell",
+                    setCode = "ICE",
+                    sku = "BM-2",
+                    variantType = VariantType.FOIL,
+                    priceInCents = 350,
+                    seller = Seller.BOOTLEG_MAGE,
+                ),
+                qty = 2,
+                isProxy = true,
+            ),
+        )
+        val export = source.formatForExport(items)
+        val lines = export.lines()
+        assertEquals(2, lines.size)
+        assertEquals("4 Lightning Bolt", lines[0])
+        assertEquals("2 Counterspell", lines[1])
+    }
+
+    @Test
+    fun `formatForExport with empty list returns empty string`() {
+        assertEquals("", source.formatForExport(emptyList()))
+    }
+
+    // ---- parseProductName ----
+
+    @Test
+    fun `parseProductName with full format Card - SET - Variant`() {
+        val result = source.parseProductName("Lightning Bolt - M11 - Foil")
+        assertNotNull(result)
+        assertEquals("Lightning Bolt", result.cardName)
+        assertEquals("M11", result.setCode)
+        assertEquals(VariantType.FOIL, result.variantType)
+    }
+
+    @Test
+    fun `parseProductName with regular variant`() {
+        val result = source.parseProductName("Dark Ritual - ICE - Regular")
+        assertNotNull(result)
+        assertEquals("Dark Ritual", result.cardName)
+        assertEquals("ICE", result.setCode)
+        assertEquals(VariantType.REGULAR, result.variantType)
+    }
+
+    @Test
+    fun `parseProductName with holo variant`() {
+        val result = source.parseProductName("Sol Ring - CMD - Holo")
+        assertNotNull(result)
+        assertEquals("Sol Ring", result.cardName)
+        assertEquals("CMD", result.setCode)
+        assertEquals(VariantType.HOLO, result.variantType)
+    }
+
+    @Test
+    fun `parseProductName with two parts defaults to Regular`() {
+        val result = source.parseProductName("Lightning Bolt - M11")
+        assertNotNull(result)
+        assertEquals("Lightning Bolt", result.cardName)
+        assertEquals("M11", result.setCode)
+        assertEquals(VariantType.REGULAR, result.variantType)
+    }
+
+    @Test
+    fun `parseProductName with single name defaults to UNK set and Regular`() {
+        val result = source.parseProductName("Lightning Bolt")
+        assertNotNull(result)
+        assertEquals("Lightning Bolt", result.cardName)
+        assertEquals("UNK", result.setCode)
+        assertEquals(VariantType.REGULAR, result.variantType)
+    }
+
+    @Test
+    fun `parseProductName with blank returns null`() {
+        assertNull(source.parseProductName(""))
+        assertNull(source.parseProductName("   "))
+    }
+
+    @Test
+    fun `parseProductName uppercases set code`() {
+        val result = source.parseProductName("Card - m11 - Foil")
+        assertNotNull(result)
+        assertEquals("M11", result.setCode)
+    }
+
+    @Test
+    fun `parseProductName with card name containing dashes`() {
+        // Card name "Nicol Bolas, Dragon-God" wouldn't use " - " separator, but
+        // a name like "Fire - Ice" (split card) that has " - " in it with extra parts
+        val result = source.parseProductName("Fire // Ice - STA - Foil")
+        assertNotNull(result)
+        assertEquals("Fire // Ice", result.cardName)
+        assertEquals("STA", result.setCode)
+        assertEquals(VariantType.FOIL, result.variantType)
+    }
+
+    @Test
+    fun `parseProductName with four-part name preserves card name with dashes`() {
+        val result = source.parseProductName("Some - Card - SET - Holo")
+        assertNotNull(result)
+        assertEquals("Some - Card", result.cardName)
+        assertEquals("SET", result.setCode)
+        assertEquals(VariantType.HOLO, result.variantType)
+    }
+
+    // ---- parseWooCommerceJson ----
+
+    @Test
+    fun `parseWooCommerceJson with valid product array`() {
+        val json = """
+            [
+                {
+                    "id": 42,
+                    "name": "Lightning Bolt - M11 - Foil",
+                    "price": "3.50",
+                    "permalink": "https://bootlegmage.com/product/lightning-bolt-m11-foil/",
+                    "images": [{"src": "https://bootlegmage.com/img/bolt.jpg"}]
+                }
+            ]
+        """.trimIndent()
+        val variants = source.parseWooCommerceJson(json)
+        assertEquals(1, variants.size)
+        val v = variants[0]
+        assertEquals("Lightning Bolt", v.nameOriginal)
+        assertEquals("lightning bolt", v.nameNormalized)
+        assertEquals("M11", v.setCode)
+        assertEquals("BM-42", v.sku)
+        assertEquals(VariantType.FOIL, v.variantType)
+        assertEquals(350, v.priceInCents)
+        assertEquals(Seller.BOOTLEG_MAGE, v.seller)
+        assertEquals("https://bootlegmage.com/product/lightning-bolt-m11-foil/", v.purchaseUri)
+        assertEquals("https://bootlegmage.com/img/bolt.jpg", v.imageUrl)
+    }
+
+    @Test
+    fun `parseWooCommerceJson with multiple products`() {
+        val json = """
+            [
+                {"id": 1, "name": "Lightning Bolt - M11 - Regular", "price": "2.20"},
+                {"id": 2, "name": "Counterspell - ICE - Foil", "price": "3.50"},
+                {"id": 3, "name": "Sol Ring - CMD - Holo", "price": "3.00"}
+            ]
+        """.trimIndent()
+        val variants = source.parseWooCommerceJson(json)
+        assertEquals(3, variants.size)
+        assertEquals(VariantType.REGULAR, variants[0].variantType)
+        assertEquals(VariantType.FOIL, variants[1].variantType)
+        assertEquals(VariantType.HOLO, variants[2].variantType)
+    }
+
+    @Test
+    fun `parseWooCommerceJson uses default price when price is zero`() {
+        val json = """[{"id": 1, "name": "Card - SET - Foil", "price": "0"}]"""
+        val variants = source.parseWooCommerceJson(json)
+        assertEquals(1, variants.size)
+        assertEquals(VariantType.FOIL.defaultPriceInCents, variants[0].priceInCents)
+    }
+
+    @Test
+    fun `parseWooCommerceJson skips products without name`() {
+        val json = """[{"id": 1, "price": "2.20"}]"""
+        val variants = source.parseWooCommerceJson(json)
+        assertTrue(variants.isEmpty())
+    }
+
+    @Test
+    fun `parseWooCommerceJson returns empty for blank input`() {
+        assertTrue(source.parseWooCommerceJson("").isEmpty())
+        assertTrue(source.parseWooCommerceJson("   ").isEmpty())
+    }
+
+    @Test
+    fun `parseWooCommerceJson returns empty for malformed JSON`() {
+        assertTrue(source.parseWooCommerceJson("not json").isEmpty())
+    }
+
+    @Test
+    fun `parseWooCommerceJson handles missing optional fields`() {
+        val json = """[{"id": 5, "name": "Dark Ritual - ICE - Regular", "price": "2.20"}]"""
+        val variants = source.parseWooCommerceJson(json)
+        assertEquals(1, variants.size)
+        assertNull(variants[0].imageUrl)
+        assertNull(variants[0].purchaseUri)
+    }
+
+    // ---- parseShopHtml ----
+
+    @Test
+    fun `parseShopHtml with WooCommerce product listing`() {
+        val html = """
+            <html><body>
+            <ul class="products">
+                <li class="product">
+                    <a href="https://bootlegmage.com/product/bolt/">
+                        <img src="https://bootlegmage.com/img/bolt.jpg" />
+                        <h2 class="woocommerce-loop-product__title">Lightning Bolt - M11 - Foil</h2>
+                        <span class="woocommerce-Price-amount">$3.50</span>
+                    </a>
+                </li>
+            </ul>
+            </body></html>
+        """.trimIndent()
+        val variants = source.parseShopHtml(html)
+        assertEquals(1, variants.size)
+        val v = variants[0]
+        assertEquals("Lightning Bolt", v.nameOriginal)
+        assertEquals("M11", v.setCode)
+        assertEquals(VariantType.FOIL, v.variantType)
+        assertEquals(350, v.priceInCents)
+        assertEquals(Seller.BOOTLEG_MAGE, v.seller)
+        assertEquals("BM-HTML-1", v.sku)
+    }
+
+    @Test
+    fun `parseShopHtml with div products`() {
+        val html = """
+            <html><body>
+            <div class="product">
+                <a href="https://bootlegmage.com/product/ritual/">
+                    <h2>Dark Ritual - ICE - Regular</h2>
+                    <span class="price">$2.20</span>
+                </a>
+            </div>
+            </body></html>
+        """.trimIndent()
+        val variants = source.parseShopHtml(html)
+        assertEquals(1, variants.size)
+        assertEquals("Dark Ritual", variants[0].nameOriginal)
+        assertEquals("ICE", variants[0].setCode)
+    }
+
+    @Test
+    fun `parseShopHtml returns empty for blank HTML`() {
+        assertTrue(source.parseShopHtml("").isEmpty())
+    }
+
+    @Test
+    fun `parseShopHtml returns empty when no products found`() {
+        val html = "<html><body><p>No products</p></body></html>"
+        assertTrue(source.parseShopHtml(html).isEmpty())
+    }
+
+    @Test
+    fun `parseShopHtml with multiple products`() {
+        val html = """
+            <html><body>
+            <ul class="products">
+                <li class="product">
+                    <a href="/p/1"><h2 class="woocommerce-loop-product__title">Card A - SET - Regular</h2></a>
+                    <span class="woocommerce-Price-amount">$2.20</span>
+                </li>
+                <li class="product">
+                    <a href="/p/2"><h2 class="woocommerce-loop-product__title">Card B - SET - Foil</h2></a>
+                    <span class="woocommerce-Price-amount">$3.50</span>
+                </li>
+            </ul>
+            </body></html>
+        """.trimIndent()
+        val variants = source.parseShopHtml(html)
+        assertEquals(2, variants.size)
+        assertEquals("BM-HTML-1", variants[0].sku)
+        assertEquals("BM-HTML-2", variants[1].sku)
+    }
+
+    // ---- all variants tagged with BOOTLEG_MAGE seller ----
+
+    @Test
+    fun `all parsed variants have BOOTLEG_MAGE seller`() {
+        val json = """
+            [
+                {"id": 1, "name": "Card A - SET - Regular", "price": "2.20"},
+                {"id": 2, "name": "Card B - SET - Foil", "price": "3.50"}
+            ]
+        """.trimIndent()
+        val variants = source.parseWooCommerceJson(json)
+        assertTrue(variants.all { it.seller == Seller.BOOTLEG_MAGE })
+    }
+
+    @Test
+    fun `HTML parsed variants have BOOTLEG_MAGE seller`() {
+        val html = """
+            <html><body>
+            <li class="product">
+                <h2 class="woocommerce-loop-product__title">Card - SET - Holo</h2>
+                <span class="price">$3.00</span>
+            </li>
+            </body></html>
+        """.trimIndent()
+        val variants = source.parseShopHtml(html)
+        assertTrue(variants.all { it.seller == Seller.BOOTLEG_MAGE })
+    }
+
+    // ---- helper ----
+
+    private fun sampleOrderItem() = OrderItem(
+        variant = CardVariant(
+            nameOriginal = "Lightning Bolt",
+            nameNormalized = "lightning bolt",
+            setCode = "M11",
+            sku = "BM-1",
+            variantType = VariantType.REGULAR,
+            priceInCents = 220,
+            seller = Seller.BOOTLEG_MAGE,
+        ),
+        qty = 4,
+        isProxy = true,
+    )
+}


### PR DESCRIPTION
## Summary

- Implements `BootlegMageCatalogSource` with dual-strategy catalog fetching: WooCommerce REST API first, HTML scraping fallback via Ksoup
- Parses Bootleg Mage product names in "Card Name - SET - Variant" format (e.g., "Lightning Bolt - M11 - Foil")
- Tags all variants with `Seller.BOOTLEG_MAGE`, returns `https://bootlegmage.com/deck-import/` as checkout URL
- Export format: `qty CardName` per line (Bootleg Mage deck import format)
- Handles graceful degradation: 401/403 from WooCommerce API triggers HTML fallback, network errors return empty list

Closes #130

## Test plan

- [x] `./gradlew build` — compiles successfully
- [x] `./gradlew detekt` — static analysis passes (baseline updated for new file)
- [x] `./gradlew allTests` — all unit tests pass
- [x] Product name parsing: full format, two-part, single name, blank, card names with dashes
- [x] WooCommerce JSON parsing: valid products, missing fields, malformed JSON, default price fallback
- [x] HTML scraping: li.product and div.product layouts, multiple products, empty/no-product HTML
- [x] Export format: qty + card name per line, empty list
- [x] Checkout URL: always returns deck-import URL
- [x] All parsed variants tagged with `Seller.BOOTLEG_MAGE`