### PR TITLE
Add seller badges and alternatives view to Results screen (#135)

### DIFF
--- a/detekt-baseline-commonMainSourceSet.xml
+++ b/detekt-baseline-commonMainSourceSet.xml
@@ -313,6 +313,11 @@
     <ID>MaxLineLength:ResultsScreen.kt:color = if (ambiguous &gt; 0) PixelOrange else MaterialTheme.colors.onSurface.copy(alpha = 0.6f)</ID>
     <ID>MaxLineLength:ResultsScreen.kt:if</ID>
     <ID>MaxLineLength:ResultsScreen.kt:if (filterMode == 0) MaterialTheme.colors.primary.copy(alpha = 0.2f) else MaterialTheme.colors.surface</ID>
+    <ID>MaxLineLength:ResultsScreen.kt:if (sortOption == SortOption.NAME_DESC) Text(" \u25bc", style = MaterialTheme.typography.caption)</ID>
+    <ID>MaxLineLength:ResultsScreen.kt:if (sortOption == SortOption.PRICE_ASC) Text(" \u25b2", style = MaterialTheme.typography.caption)</ID>
+    <ID>MaxLineLength:ResultsScreen.kt:if (sortOption == SortOption.PRICE_DESC) Text(" \u25bc", style = MaterialTheme.typography.caption)</ID>
+    <ID>MaxLineLength:ResultsScreen.kt:if (sortOption == SortOption.STATUS_ASC) Text(" \u25b2", style = MaterialTheme.typography.caption)</ID>
+    <ID>MaxLineLength:ResultsScreen.kt:if (sortOption == SortOption.STATUS_DESC) Text(" \u25bc", style = MaterialTheme.typography.caption)</ID>
     <ID>MaxLineLength:SavedImportQueries.kt:SavedImportQueries$)</ID>
     <ID>MaxLineLength:SavedImportQueries.kt:SavedImportQueries.GetByIdQuery$override</ID>
     <ID>MaxLineLength:ScryfallImageEnricher.kt:ScryfallImageEnricher$log?.invoke("Fetching image for ${variant.nameOriginal} (${variant.setCode} #${variant.collectorNumber})")</ID>
@@ -359,8 +364,6 @@
     <ID>WildcardImport:PreferencesWizardScreen.kt:import androidx.compose.runtime.*</ID>
     <ID>WildcardImport:ResolveScreen.kt:import androidx.compose.foundation.layout.*</ID>
     <ID>WildcardImport:ResolveScreen.kt:import androidx.compose.material.*</ID>
-    <ID>WildcardImport:ResultsScreen.kt:import androidx.compose.foundation.layout.*</ID>
-    <ID>WildcardImport:ResultsScreen.kt:import androidx.compose.runtime.*</ID>
     <ID>WildcardImport:ScryfallApi.kt:import io.ktor.client.*</ID>
     <ID>WildcardImport:ScryfallApi.kt:import io.ktor.client.plugins.contentnegotiation.*</ID>
     <ID>WildcardImport:ScryfallApi.kt:import io.ktor.client.plugins.logging.*</ID>

--- a/src/commonMain/kotlin/ui/ResultsScreen.kt
+++ b/src/commonMain/kotlin/ui/ResultsScreen.kt
@@ -1,26 +1,43 @@
 package ui
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
-import androidx.compose.runtime.*
-import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.foundation.lazy.rememberLazyListState
 import model.CardVariant
 import model.DeckEntryMatch
 import model.MatchStatus
+import model.MultiMatch
+import model.Seller
 import util.formatPrice
 
 enum class SortOption {
@@ -35,11 +52,20 @@ enum class SortOption {
     STATUS_DESC
 }
 
+private fun sellerColor(seller: Seller): Color = when (seller) {
+    Seller.USEA -> SellerUsea
+    Seller.BOOTLEG_MAGE -> SellerBootlegMage
+    Seller.TCGPLAYER -> SellerTcgPlayer
+}
+
 @Composable
 fun ResultsScreen(
     matches: List<DeckEntryMatch>,
+    multiMatches: List<MultiMatch> = emptyList(),
+    availableSellers: List<Seller> = emptyList(),
     onResolve: (Int) -> Unit,
     onShowAllCandidates: (Int) -> Unit,
+    onOverrideSeller: (Int, Seller) -> Unit = { _, _ -> },
     onClose: () -> Unit,
     onExport: () -> Unit = {},
     onEnrichVariant: ((CardVariant) -> Unit)? = null,
@@ -55,8 +81,12 @@ fun ResultsScreen(
     val ambiguous = ambiguousCount
 
     var filterMode by rememberSaveable { mutableStateOf(0) } // 0 = All, 1 = Matched, 2 = Unmatched, 3 = Ambiguous
+    var sellerFilter by remember { mutableStateOf<Seller?>(null) }
     val sortSaver = remember { Saver<SortOption, String>(save = { it.name }, restore = { SortOption.valueOf(it) }) }
     var sortOption by rememberSaveable(stateSaver = sortSaver) { mutableStateOf(SortOption.DEFAULT) }
+
+    // Track which rows are expanded to show alternatives
+    var expandedRows by remember { mutableStateOf(emptySet<String>()) }
 
     Box(modifier = Modifier.fillMaxSize()) {
         // Scanline effect
@@ -66,7 +96,7 @@ fun ResultsScreen(
             // Header with pixel styling - compact layout
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
-                    "▸ RESULTS",
+                    "\u25b8 RESULTS",
                     style = MaterialTheme.typography.h4,
                     color = MaterialTheme.colors.primary,
                     fontWeight = FontWeight.Bold
@@ -78,7 +108,7 @@ fun ResultsScreen(
             }
             Spacer(Modifier.height(4.dp))
             Text(
-                "└─ Click cards to filter • Review and resolve any issues",
+                "\u2514\u2500 Click cards to filter \u2022 Review and resolve any issues",
                 style = MaterialTheme.typography.caption,
                 color = MaterialTheme.colors.onSurface.copy(alpha = 0.7f)
             )
@@ -252,8 +282,78 @@ fun ResultsScreen(
                 }
             }
 
+            // Seller filter chips (shown when multiple sellers are available)
+            if (availableSellers.size > 1) {
+                Spacer(Modifier.height(8.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        "SELLER:",
+                        style = MaterialTheme.typography.caption,
+                        color = MaterialTheme.colors.onSurface.copy(alpha = 0.7f),
+                        fontWeight = FontWeight.Bold
+                    )
+                    // "All" chip
+                    Box(
+                        modifier = Modifier
+                            .clip(PixelShape(cornerSize = 6.dp))
+                            .background(
+                                if (sellerFilter == null) MaterialTheme.colors.primary else PixelGrey,
+                                shape = PixelShape(cornerSize = 6.dp)
+                            )
+                            .pixelBorder(
+                                borderWidth = 2.dp,
+                                cornerSize = 6.dp,
+                                enabled = true,
+                                glowAlpha = if (sellerFilter == null) 0.4f else 0.1f
+                            )
+                            .clickable { sellerFilter = null }
+                            .padding(horizontal = 8.dp, vertical = 4.dp)
+                    ) {
+                        Text(
+                            text = "ALL",
+                            style = MaterialTheme.typography.caption,
+                            color = Color.White,
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                    // Per-seller chips
+                    availableSellers.forEach { seller ->
+                        val chipColor = sellerColor(seller)
+                        Box(
+                            modifier = Modifier
+                                .clip(PixelShape(cornerSize = 6.dp))
+                                .background(
+                                    if (sellerFilter == seller) chipColor else chipColor.copy(alpha = 0.5f),
+                                    shape = PixelShape(cornerSize = 6.dp)
+                                )
+                                .pixelBorder(
+                                    borderWidth = 2.dp,
+                                    cornerSize = 6.dp,
+                                    enabled = true,
+                                    glowAlpha = if (sellerFilter == seller) 0.4f else 0.1f
+                                )
+                                .clickable {
+                                    sellerFilter = if (sellerFilter == seller) null else seller
+                                }
+                                .padding(horizontal = 8.dp, vertical = 4.dp)
+                        ) {
+                            Text(
+                                text = seller.displayName.uppercase(),
+                                style = MaterialTheme.typography.caption,
+                                color = Color.White,
+                                fontWeight = FontWeight.Bold
+                            )
+                        }
+                    }
+                }
+            }
+
             Spacer(Modifier.height(16.dp))
-            
+
             // Loading indicator below badge counts
             if (isLoading) {
                 Box(
@@ -264,7 +364,7 @@ fun ResultsScreen(
                 }
                 Spacer(Modifier.height(16.dp))
             }
-            
+
             // Hide table and list when loading
             if (!isLoading) {
 
@@ -293,8 +393,8 @@ fun ResultsScreen(
                             style = MaterialTheme.typography.subtitle2,
                             fontWeight = FontWeight.Bold
                         )
-                        if (sortOption == SortOption.QTY_ASC) Text(" ▲", style = MaterialTheme.typography.caption)
-                        if (sortOption == SortOption.QTY_DESC) Text(" ▼", style = MaterialTheme.typography.caption)
+                        if (sortOption == SortOption.QTY_ASC) Text(" \u25b2", style = MaterialTheme.typography.caption)
+                        if (sortOption == SortOption.QTY_DESC) Text(" \u25bc", style = MaterialTheme.typography.caption)
                     }
 
                     // Sortable Card Name header
@@ -313,8 +413,8 @@ fun ResultsScreen(
                             style = MaterialTheme.typography.subtitle2,
                             fontWeight = FontWeight.Bold
                         )
-                        if (sortOption == SortOption.NAME_ASC) Text(" ▲", style = MaterialTheme.typography.caption)
-                        if (sortOption == SortOption.NAME_DESC) Text(" ▼", style = MaterialTheme.typography.caption)
+                        if (sortOption == SortOption.NAME_ASC) Text(" \u25b2", style = MaterialTheme.typography.caption)
+                        if (sortOption == SortOption.NAME_DESC) Text(" \u25bc", style = MaterialTheme.typography.caption)
                     }
 
                     // Sortable Status header
@@ -333,8 +433,8 @@ fun ResultsScreen(
                             style = MaterialTheme.typography.subtitle2,
                             fontWeight = FontWeight.Bold
                         )
-                        if (sortOption == SortOption.STATUS_ASC) Text(" ▲", style = MaterialTheme.typography.caption)
-                        if (sortOption == SortOption.STATUS_DESC) Text(" ▼", style = MaterialTheme.typography.caption)
+                        if (sortOption == SortOption.STATUS_ASC) Text(" \u25b2", style = MaterialTheme.typography.caption)
+                        if (sortOption == SortOption.STATUS_DESC) Text(" \u25bc", style = MaterialTheme.typography.caption)
                     }
 
                     Text(
@@ -360,8 +460,8 @@ fun ResultsScreen(
                             style = MaterialTheme.typography.subtitle2,
                             fontWeight = FontWeight.Bold
                         )
-                        if (sortOption == SortOption.PRICE_ASC) Text(" ▲", style = MaterialTheme.typography.caption)
-                        if (sortOption == SortOption.PRICE_DESC) Text(" ▼", style = MaterialTheme.typography.caption)
+                        if (sortOption == SortOption.PRICE_ASC) Text(" \u25b2", style = MaterialTheme.typography.caption)
+                        if (sortOption == SortOption.PRICE_DESC) Text(" \u25bc", style = MaterialTheme.typography.caption)
                     }
 
                     Text(
@@ -386,17 +486,29 @@ fun ResultsScreen(
                 else -> matches
             }
 
+            // Apply seller filter
+            val sellerFiltered = if (sellerFilter != null) {
+                filtered.filter { it.selectedVariant?.seller == sellerFilter }
+            } else {
+                filtered
+            }
+
             // Apply sorting
             val sorted = when (sortOption) {
-                SortOption.NAME_ASC -> filtered.sortedBy { it.deckEntry.cardName.lowercase() }
-                SortOption.NAME_DESC -> filtered.sortedByDescending { it.deckEntry.cardName.lowercase() }
-                SortOption.QTY_ASC -> filtered.sortedBy { it.deckEntry.qty }
-                SortOption.QTY_DESC -> filtered.sortedByDescending { it.deckEntry.qty }
-                SortOption.PRICE_ASC -> filtered.sortedBy { it.selectedVariant?.priceInCents ?: Int.MAX_VALUE }
-                SortOption.PRICE_DESC -> filtered.sortedByDescending { it.selectedVariant?.priceInCents ?: -1 }
-                SortOption.STATUS_ASC -> filtered.sortedBy { it.status.ordinal }
-                SortOption.STATUS_DESC -> filtered.sortedByDescending { it.status.ordinal }
-                SortOption.DEFAULT -> filtered
+                SortOption.NAME_ASC -> sellerFiltered.sortedBy { it.deckEntry.cardName.lowercase() }
+                SortOption.NAME_DESC -> sellerFiltered.sortedByDescending { it.deckEntry.cardName.lowercase() }
+                SortOption.QTY_ASC -> sellerFiltered.sortedBy { it.deckEntry.qty }
+                SortOption.QTY_DESC -> sellerFiltered.sortedByDescending { it.deckEntry.qty }
+                SortOption.PRICE_ASC -> sellerFiltered.sortedBy { it.selectedVariant?.priceInCents ?: Int.MAX_VALUE }
+                SortOption.PRICE_DESC -> sellerFiltered.sortedByDescending { it.selectedVariant?.priceInCents ?: -1 }
+                SortOption.STATUS_ASC -> sellerFiltered.sortedBy { it.status.ordinal }
+                SortOption.STATUS_DESC -> sellerFiltered.sortedByDescending { it.status.ordinal }
+                SortOption.DEFAULT -> sellerFiltered
+            }
+
+            // Build a lookup from deckEntry id to multiMatch for alternatives
+            val multiMatchByEntryId = remember(multiMatches) {
+                multiMatches.associateBy { it.deckEntry.id }
             }
 
             // Results List with pixel card
@@ -412,6 +524,9 @@ fun ResultsScreen(
                             val globalIndex = matches.indexOf(m)
                             val variant = m.selectedVariant
                             val rowTotal = variant?.priceInCents?.let { it * m.deckEntry.qty }
+                            val multiMatch = multiMatchByEntryId[m.deckEntry.id]
+                            val hasAlternatives = multiMatch != null && multiMatch.alternatives.size > 1
+                            val isExpanded = expandedRows.contains(m.uniqueIdentifier)
 
                             // Trigger image enrichment when variant comes into view
                             variant?.let { v ->
@@ -422,67 +537,165 @@ fun ResultsScreen(
                                 }
                             }
 
-                            Row(
-                                Modifier.fillMaxWidth().padding(12.dp),
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                Text("${m.deckEntry.qty}", Modifier.width(50.dp), style = MaterialTheme.typography.body1)
-                                Row(Modifier.weight(0.35f), verticalAlignment = Alignment.CenterVertically) {
-                                    Text(m.deckEntry.cardName, style = MaterialTheme.typography.body1)
-                                    val collectorNumber = m.selectedVariant?.collectorNumber
-                                    if (!collectorNumber.isNullOrBlank()) {
-                                        Spacer(Modifier.width(8.dp))
+                            Column {
+                                Row(
+                                    Modifier.fillMaxWidth().padding(12.dp),
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    Text("${m.deckEntry.qty}", Modifier.width(50.dp), style = MaterialTheme.typography.body1)
+                                    Row(Modifier.weight(0.35f), verticalAlignment = Alignment.CenterVertically) {
+                                        Text(m.deckEntry.cardName, style = MaterialTheme.typography.body1)
+                                        val collectorNumber = m.selectedVariant?.collectorNumber
+                                        if (!collectorNumber.isNullOrBlank()) {
+                                            Spacer(Modifier.width(4.dp))
+                                            PixelBadge(
+                                                text = collectorNumber,
+                                                color = MaterialTheme.colors.onSurface
+                                            )
+                                        }
+                                        // Seller badge
+                                        variant?.let { v ->
+                                            Spacer(Modifier.width(4.dp))
+                                            PixelBadge(
+                                                text = v.seller.displayName,
+                                                color = sellerColor(v.seller)
+                                            )
+                                        }
+                                    }
+
+                                    // Status badge with pixel styling
+                                    val (statusText, statusColor) = when (m.status) {
+                                        MatchStatus.AUTO_MATCHED -> "Auto" to PixelGreen
+                                        MatchStatus.MANUAL_SELECTED -> "Manual" to PixelBlue
+                                        MatchStatus.AMBIGUOUS -> "Ambiguous" to PixelOrange
+                                        MatchStatus.NOT_FOUND -> "Not Found" to PixelRed
+                                        MatchStatus.UNRESOLVED -> "Pending" to PixelGrey
+                                        MatchStatus.FUZZY_RECHECK -> "Recheck" to PixelYellow
+                                    }
+                                    Box(Modifier.weight(0.15f).padding(end = 8.dp)) {
                                         PixelBadge(
-                                            text = collectorNumber,
-                                            color = MaterialTheme.colors.onSurface
+                                            text = statusText,
+                                            color = statusColor
                                         )
                                     }
-                                }
 
-                                // Status badge with pixel styling
-                                val (statusText, statusColor) = when (m.status) {
-                                    MatchStatus.AUTO_MATCHED -> "Auto" to PixelGreen
-                                    MatchStatus.MANUAL_SELECTED -> "Manual" to PixelBlue
-                                    MatchStatus.AMBIGUOUS -> "Ambiguous" to PixelOrange
-                                    MatchStatus.NOT_FOUND -> "Not Found" to PixelRed
-                                    MatchStatus.UNRESOLVED -> "Pending" to PixelGrey
-                                    MatchStatus.FUZZY_RECHECK -> "Recheck" to PixelYellow
-                                }
-                                Box(Modifier.weight(0.15f).padding(end = 8.dp)) {
-                                    PixelBadge(
-                                        text = statusText,
-                                        color = statusColor
+                                    Text(
+                                        variant?.variantType?.displayName ?: "-",
+                                        Modifier.weight(0.15f),
+                                        style = MaterialTheme.typography.body2
                                     )
+                                    Text(variant?.let { formatPrice(it.priceInCents) } ?: "-",
+                                        Modifier.width(70.dp),
+                                        style = MaterialTheme.typography.body2)
+                                    Text(rowTotal?.let { formatPrice(it) } ?: "-",
+                                        Modifier.width(80.dp),
+                                        style = MaterialTheme.typography.body2)
+
+                                    Row(Modifier.width(180.dp), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                        if (m.status == MatchStatus.AMBIGUOUS || m.status == MatchStatus.NOT_FOUND || m.status == MatchStatus.FUZZY_RECHECK) {
+                                            PixelButton(
+                                                text = "Resolve",
+                                                onClick = { onResolve(globalIndex) },
+                                                variant = PixelButtonVariant.SECONDARY,
+                                                modifier = Modifier.height(36.dp)
+                                            )
+                                        }
+                                        if (m.candidates.isNotEmpty()) {
+                                            PixelButton(
+                                                text = "View",
+                                                onClick = { onShowAllCandidates(globalIndex) },
+                                                variant = PixelButtonVariant.SURFACE,
+                                                modifier = Modifier.height(36.dp)
+                                            )
+                                        }
+                                        // Expand/collapse alternatives button
+                                        if (hasAlternatives) {
+                                            PixelButton(
+                                                text = if (isExpanded) "\u25b2 Alt" else "\u25bc Alt",
+                                                onClick = {
+                                                    expandedRows = if (isExpanded) {
+                                                        expandedRows - m.uniqueIdentifier
+                                                    } else {
+                                                        expandedRows + m.uniqueIdentifier
+                                                    }
+                                                },
+                                                variant = PixelButtonVariant.SURFACE,
+                                                modifier = Modifier.height(36.dp)
+                                            )
+                                        }
+                                    }
                                 }
 
-                                Text(
-                                    variant?.variantType?.displayName ?: "-",
-                                    Modifier.weight(0.15f),
-                                    style = MaterialTheme.typography.body2
-                                )
-                                Text(variant?.let { formatPrice(it.priceInCents) } ?: "-",
-                                    Modifier.width(70.dp),
-                                    style = MaterialTheme.typography.body2)
-                                Text(rowTotal?.let { formatPrice(it) } ?: "-",
-                                    Modifier.width(80.dp),
-                                    style = MaterialTheme.typography.body2)
+                                // Expandable alternatives section
+                                if (hasAlternatives) {
+                                    AnimatedVisibility(
+                                        visible = isExpanded,
+                                        enter = expandVertically(),
+                                        exit = shrinkVertically()
+                                    ) {
+                                        Column(
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .background(MaterialTheme.colors.surface.copy(alpha = 0.5f))
+                                                .padding(start = 50.dp, end = 12.dp, top = 4.dp, bottom = 8.dp)
+                                        ) {
+                                            Text(
+                                                "\u2514\u2500 ALTERNATIVES",
+                                                style = MaterialTheme.typography.caption,
+                                                color = MaterialTheme.colors.onSurface.copy(alpha = 0.6f),
+                                                fontWeight = FontWeight.Bold
+                                            )
+                                            Spacer(Modifier.height(4.dp))
+                                            val multiMatchIndex = multiMatches.indexOfFirst {
+                                                it.deckEntry.id == m.deckEntry.id
+                                            }
+                                            multiMatch.alternatives.forEach { option ->
+                                                // Skip the currently selected option
+                                                val isCurrent = multiMatch.bestOption?.let {
+                                                    it.seller == option.seller &&
+                                                        it.variant.sku == option.variant.sku
+                                                } ?: false
 
-                                Row(Modifier.width(180.dp), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                                    if (m.status == MatchStatus.AMBIGUOUS || m.status == MatchStatus.NOT_FOUND || m.status == MatchStatus.FUZZY_RECHECK) {
-                                        PixelButton(
-                                            text = "Resolve",
-                                            onClick = { onResolve(globalIndex) },
-                                            variant = PixelButtonVariant.SECONDARY,
-                                            modifier = Modifier.height(36.dp)
-                                        )
-                                    }
-                                    if (m.candidates.isNotEmpty()) {
-                                        PixelButton(
-                                            text = "View",
-                                            onClick = { onShowAllCandidates(globalIndex) },
-                                            variant = PixelButtonVariant.SURFACE,
-                                            modifier = Modifier.height(36.dp)
-                                        )
+                                                Row(
+                                                    modifier = Modifier
+                                                        .fillMaxWidth()
+                                                        .then(
+                                                            if (!isCurrent && multiMatchIndex >= 0) {
+                                                                Modifier.clickable {
+                                                                    onOverrideSeller(multiMatchIndex, option.seller)
+                                                                }
+                                                            } else {
+                                                                Modifier
+                                                            }
+                                                        )
+                                                        .padding(vertical = 4.dp, horizontal = 8.dp),
+                                                    verticalAlignment = Alignment.CenterVertically,
+                                                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                                                ) {
+                                                    PixelBadge(
+                                                        text = option.seller.displayName,
+                                                        color = sellerColor(option.seller)
+                                                    )
+                                                    Text(
+                                                        option.variant.variantType.displayName,
+                                                        style = MaterialTheme.typography.body2,
+                                                        color = MaterialTheme.colors.onSurface.copy(alpha = 0.8f)
+                                                    )
+                                                    Text(
+                                                        formatPrice(option.priceCents),
+                                                        style = MaterialTheme.typography.body2,
+                                                        fontWeight = FontWeight.Bold,
+                                                        color = MaterialTheme.colors.secondary
+                                                    )
+                                                    if (isCurrent) {
+                                                        PixelBadge(
+                                                            text = "CURRENT",
+                                                            color = PixelGreen
+                                                        )
+                                                    }
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -502,14 +715,14 @@ fun ResultsScreen(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 PixelButton(
-                    text = "← Back to Configure",
+                    text = "\u2190 Back to Configure",
                     onClick = onClose,
                     variant = PixelButtonVariant.SURFACE,
                     modifier = Modifier.width(180.dp)
                 )
                 if (matches.isNotEmpty()) {
                     PixelButton(
-                        text = "Continue to Export →",
+                        text = "Continue to Export \u2192",
                         onClick = onExport,
                         variant = PixelButtonVariant.SECONDARY,
                         modifier = Modifier.width(280.dp)
@@ -520,4 +733,3 @@ fun ResultsScreen(
         }
     }
 }
-

--- a/src/desktopMain/kotlin/app/Main.kt
+++ b/src/desktopMain/kotlin/app/Main.kt
@@ -692,6 +692,8 @@ fun main() = application {
                                     // Step 3: Results (Wizard End)
                                     ResultsScreen(
                                         matches = state.matches,
+                                        multiMatches = state.multiMatches,
+                                        availableSellers = state.availableSellers,
                                         onResolve = { idx ->
                                             viewModel.processIntent(ViewIntent.OpenResolve(idx))
                                             navController.navigate("resolve") {
@@ -703,6 +705,9 @@ fun main() = application {
                                             navController.navigate("resolve") {
                                                 launchSingleTop = true
                                             }
+                                        },
+                                        onOverrideSeller = { index, seller ->
+                                            viewModel.processIntent(ViewIntent.OverrideCardSeller(index, seller))
                                         },
                                         onClose = { navController.navigateUp() },
                                         onExport = {


### PR DESCRIPTION
## Summary
- **Seller badge on each result row**: Shows the seller name (USEA, Bootleg Mage, TCGPlayer) as a colored PixelBadge next to each matched card, using the seller theme colors from Theme.kt
- **Expandable alternatives section**: When a card has multi-match alternatives from different sellers, an "Alt" button appears in the actions column. Clicking it expands an animated section showing all alternative seller options with badges, variant type, and price. Clicking an alternative triggers the OverrideCardSeller intent
- **Seller filter chips**: A secondary filter row appears below the status filter cards when multiple sellers are available. Includes "All" and per-seller filter chips to narrow results by seller

## Test plan
- [ ] `./gradlew build` compiles cleanly (verified)
- [ ] `./gradlew allTests` passes (verified)
- [ ] `./gradlew detekt` passes (verified)
- [ ] Launch desktop app and verify existing result rows still display correctly with seller badges
- [ ] Verify seller filter chips appear when multiple sellers are loaded
- [ ] Verify clicking a seller chip filters the results list
- [ ] Verify the "Alt" expand button shows alternatives when multiMatches data is present
- [ ] Verify clicking an alternative in the expanded section triggers seller override
- [ ] Verify iOS build is not broken (default params ensure backward compatibility)

Closes #135