### PR TITLE
Fix build and wire multi-catalog flow into wizard

### DIFF
--- a/src/commonMain/kotlin/state/MviViewModel.kt
+++ b/src/commonMain/kotlin/state/MviViewModel.kt
@@ -513,6 +513,10 @@ class MviViewModel(
             try {
                 val loadedSellers = catalogUseCase.loadAllCatalogs { msg, level -> log(msg, level) }
                 _localState.update { it.copy(availableSellers = loadedSellers) }
+                // Auto-trigger multi-match after catalogs load
+                if (loadedSellers.isNotEmpty()) {
+                    runMultiMatch()
+                }
             } catch (e: Exception) {
                 log("Failed to load multi-catalogs: ${e.message}", "ERROR")
                 _viewEffects.emit(ViewEffect.ShowError("Failed to load catalogs from sellers"))

--- a/src/commonMain/kotlin/ui/ResultsScreen.kt
+++ b/src/commonMain/kotlin/ui/ResultsScreen.kt
@@ -52,12 +52,6 @@ enum class SortOption {
     STATUS_DESC
 }
 
-private fun sellerColor(seller: Seller): Color = when (seller) {
-    Seller.USEA -> SellerUsea
-    Seller.BOOTLEG_MAGE -> SellerBootlegMage
-    Seller.TCGPLAYER -> SellerTcgPlayer
-}
-
 @Composable
 fun ResultsScreen(
     matches: List<DeckEntryMatch>,

--- a/src/desktopMain/kotlin/app/Main.kt
+++ b/src/desktopMain/kotlin/app/Main.kt
@@ -641,6 +641,7 @@ fun main() = application {
                                         onNext = {
                                             viewModel.processIntent(ViewIntent.CompleteWizardStep(2))
                                             viewModel.processIntent(ViewIntent.RunMatch)
+                                            viewModel.processIntent(ViewIntent.LoadAllCatalogs)
                                             navController.navigate("results") {
                                                 launchSingleTop = true
                                             }

--- a/src/iosMain/kotlin/app/Main.kt
+++ b/src/iosMain/kotlin/app/Main.kt
@@ -140,6 +140,7 @@ fun IosNavigationHost(
                 onNext = {
                     viewModel.processIntent(ViewIntent.CompleteWizardStep(2))
                     viewModel.processIntent(ViewIntent.RunMatch)
+                    viewModel.processIntent(ViewIntent.LoadAllCatalogs)
                     navigateTo(IosScreen.RESULTS)
                 },
                 isDarkTheme = state.isDarkTheme,
@@ -155,8 +156,8 @@ fun IosNavigationHost(
                 onBack = { navigateTo(IosScreen.PREFERENCES) },
                 onNext = {
                     viewModel.processIntent(ViewIntent.CompleteWizardStep(3))
-                    // Auto-save the import when moving to export
                     viewModel.processIntent(ViewIntent.SaveCurrentImport)
+                    viewModel.processIntent(ViewIntent.OptimizeShoppingPlan)
                     navigateTo(IosScreen.EXPORT)
                 },
                 onEnrichVariant = { variant ->


### PR DESCRIPTION
## Summary
- Fix compilation errors from duplicate `sellerColor()` function defined in both `ShoppingPlanScreen.kt` (public) and `ResultsScreen.kt` (private)
- Wire `LoadAllCatalogs` intent into the Preferences → Results navigation on both desktop and iOS
- Auto-trigger `RunMultiMatch` after multi-catalog loading completes
- Trigger `OptimizeShoppingPlan` on iOS Results → Export navigation

## Test plan
- [x] `./gradlew build` passes (was previously failing with conflicting overloads)
- [x] `./gradlew allTests` passes
- [ ] Desktop: Verify multi-seller catalogs load when navigating from Preferences to Results
- [ ] Desktop: Verify ShoppingPlanScreen shows optimized plan on export step
- [ ] iOS: Verify catalogs load and optimization triggers correctly