### PR TITLE
Fix iOS multi-seller review issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,8 +463,7 @@ MtgPirate/
 │       ├── app/
 │       │   ├── Main.kt                     # iOS entry point
 │       │   ├── IosScreens.kt               # iOS wizard screens
-│       │   ├── IosCompactStepper.kt        # Mobile stepper
-│       │   └── IosExportHelpers.kt         # CSV export helpers
+│       │   └── IosCompactStepper.kt        # Mobile stepper
 │       ├── database/
 │       │   └── DatabaseDriverFactory.kt    # SQLite Native driver
 │       ├── platform/

--- a/src/commonMain/kotlin/ui/ShoppingPlanScreen.kt
+++ b/src/commonMain/kotlin/ui/ShoppingPlanScreen.kt
@@ -39,6 +39,7 @@ import model.OrderItem
 import model.Seller
 import model.SellerOrder
 import model.ShoppingPlan
+import util.encodeUrlParameter
 import util.formatPrice
 
 private const val TCGPLAYER_MASS_ENTRY_URL = "https://www.tcgplayer.com/massentry?productline=Magic"
@@ -499,7 +500,7 @@ private fun SellerActionButtons(
                     onClick = {
                         val exportText = formatForExport(Seller.USEA, order.items)
                         val subject = "MTG Proxy Order - ${order.items.sumOf { it.qty }} cards"
-                        val mailtoUrl = "mailto:?subject=$subject&body=$exportText"
+                        val mailtoUrl = "mailto:?subject=${encodeUrlParameter(subject)}&body=${encodeUrlParameter(exportText)}"
                         onOpenUrl(mailtoUrl)
                     },
                     variant = PixelButtonVariant.SECONDARY,

--- a/src/commonMain/kotlin/util/UrlEncoding.kt
+++ b/src/commonMain/kotlin/util/UrlEncoding.kt
@@ -1,0 +1,21 @@
+package util
+
+/**
+ * Percent-encode a string for use in URL query parameters (RFC 3986).
+ * Unreserved characters (A-Z, a-z, 0-9, -, _, ., ~) are left as-is.
+ * Spaces are encoded as %20 (not +).
+ */
+fun encodeUrlParameter(value: String): String = buildString {
+    for (char in value) {
+        when {
+            char.isLetterOrDigit() || char in "-_.~" -> append(char)
+            else -> {
+                val bytes = char.toString().encodeToByteArray()
+                for (byte in bytes) {
+                    append('%')
+                    append(byte.toInt().and(0xFF).toString(16).uppercase().padStart(2, '0'))
+                }
+            }
+        }
+    }
+}

--- a/src/iosMain/kotlin/app/IosScreens.kt
+++ b/src/iosMain/kotlin/app/IosScreens.kt
@@ -67,6 +67,7 @@ import ui.PixelToggle
 import ui.ScanlineEffect
 import ui.pixelBorder
 import ui.sellerColor
+import util.encodeUrlParameter
 import util.formatPrice
 
 /**
@@ -1117,7 +1118,7 @@ private fun MobileSellerActionButtons(
                         platform.IosHapticFeedback.triggerImpact(platform.IosHapticFeedback.ImpactStyle.MEDIUM)
                         val exportText = formatForExport(Seller.USEA, order.items)
                         val subject = "MTG Proxy Order - ${order.items.sumOf { it.qty }} cards"
-                        val mailtoUrl = "mailto:?subject=$subject&body=$exportText"
+                        val mailtoUrl = "mailto:?subject=${encodeUrlParameter(subject)}&body=${encodeUrlParameter(exportText)}"
                         onOpenUrl(mailtoUrl)
                     },
                     variant = PixelButtonVariant.SECONDARY,

--- a/src/iosMain/kotlin/app/Main.kt
+++ b/src/iosMain/kotlin/app/Main.kt
@@ -162,6 +162,7 @@ fun IosNavigationHost(
                 onNext = {
                     viewModel.processIntent(ViewIntent.CompleteWizardStep(3))
                     viewModel.processIntent(ViewIntent.SaveCurrentImport)
+                    viewModel.processIntent(ViewIntent.OptimizeShoppingPlan)
                     navigateTo(IosScreen.EXPORT)
                 },
                 onEnrichVariant = { variant ->
@@ -219,6 +220,7 @@ fun IosNavigationHost(
                         scope.launch { platformServices.openUrl(url) }
                     },
                     onBack = { navigateTo(IosScreen.RESULTS) },
+                    isLoading = state.isMatching,
                     isDarkTheme = state.isDarkTheme,
                     onToggleTheme = { viewModel.processIntent(ViewIntent.ToggleTheme) },
                 )


### PR DESCRIPTION
## Summary
Follow-up fixes from code review of #153:

- **Stale shopping plan fix**: Add `OptimizeShoppingPlan` intent before export navigation so seller overrides are reflected in the shopping plan
- **Mailto URL encoding**: URL-encode subject and body in mailto links to prevent malformed URLs with commas/newlines (both desktop and iOS)
- **isLoading pass-through**: Pass `state.isMatching` to `IosShoppingPlanScreen` for desktop parity
- **README cleanup**: Remove reference to deleted `IosExportHelpers.kt`
- **New utility**: `encodeUrlParameter()` in commonMain for RFC 3986 percent-encoding

## Test plan
- [x] Build passes (`./gradlew build`)
- [ ] Navigate Results → Export after overriding a seller → shopping plan reflects the override
- [ ] Email Order button produces properly encoded mailto URL