### PR TITLE
One-click Buy buttons and purchase links on shopping screen

### DIFF
--- a/detekt-baseline-commonMainSourceSet.xml
+++ b/detekt-baseline-commonMainSourceSet.xml
@@ -48,11 +48,13 @@
     <ID>LoopWithTooManyJumpStatements:KtorRemoteCatalogDataSource.kt:KtorRemoteCatalogDataSource$while</ID>
     <ID>LoopWithTooManyJumpStatements:MultiCatalogMatcher.kt:MultiCatalogMatcher$for</ID>
     <ID>MagicNumber:BootlegMageCatalogSource.kt:BootlegMageCatalogSource$100</ID>
+    <ID>MagicNumber:BootlegMageCatalogSource.kt:BootlegMageCatalogSource$15_000</ID>
     <ID>MagicNumber:BootlegMageCatalogSource.kt:BootlegMageCatalogSource$3</ID>
     <ID>MagicNumber:BootlegMageCatalogSource.kt:BootlegMageCatalogSource$4</ID>
     <ID>MagicNumber:BootlegMageCatalogSource.kt:BootlegMageCatalogSource$401</ID>
     <ID>MagicNumber:BootlegMageCatalogSource.kt:BootlegMageCatalogSource$403</ID>
     <ID>MagicNumber:BootlegMageCatalogSource.kt:BootlegMageCatalogSource$5</ID>
+    <ID>MagicNumber:BootlegMageCatalogSource.kt:BootlegMageCatalogSource$60_000</ID>
     <ID>MagicNumber:CardVariantQueries.kt:CardVariantQueries$10</ID>
     <ID>MagicNumber:CardVariantQueries.kt:CardVariantQueries$184_426_222</ID>
     <ID>MagicNumber:CardVariantQueries.kt:CardVariantQueries$1_386_511_848</ID>
@@ -97,6 +99,8 @@
     <ID>MagicNumber:LogEntryQueries.kt:LogEntryQueries$3</ID>
     <ID>MagicNumber:LogEntryQueries.kt:LogEntryQueries$407_997_744</ID>
     <ID>MagicNumber:Logging.kt:Logging$300</ID>
+    <ID>MagicNumber:ManaPoolApi.kt:ManaPoolApi$120_000</ID>
+    <ID>MagicNumber:ManaPoolApi.kt:ManaPoolApi$30_000</ID>
     <ID>MagicNumber:MatchSorting.kt:MatchSorting$15</ID>
     <ID>MagicNumber:MatchSorting.kt:MatchSorting$3</ID>
     <ID>MagicNumber:MatchesScreen.kt:0.10f</ID>
@@ -190,6 +194,8 @@
     <ID>MagicNumber:SavedImportQueries.kt:SavedImportQueries$7</ID>
     <ID>MagicNumber:SavedImportQueries.kt:SavedImportQueries$8</ID>
     <ID>MagicNumber:SavedImportQueries.kt:SavedImportQueries.GetByIdQuery$757_582_413</ID>
+    <ID>MagicNumber:ScryfallApi.kt:ScryfallApi$15_000</ID>
+    <ID>MagicNumber:ScryfallApi.kt:ScryfallApi$60_000</ID>
     <ID>MagicNumber:ScryfallApi.kt:ScryfallApi$75</ID>
     <ID>MagicNumber:ScryfallImageEnricher.kt:ScryfallImageEnricher$10</ID>
     <ID>MagicNumber:SellerCacheQueries.kt:SellerCacheQueries$1_517_078_527</ID>
@@ -339,6 +345,7 @@
     <ID>MaxLineLength:ResolveScreen.kt:Text("PRICE", Modifier.width(80.dp), style = MaterialTheme.typography.subtitle2, fontWeight = FontWeight.Bold)</ID>
     <ID>MaxLineLength:ResolveScreen.kt:Text("SET", Modifier.width(70.dp), style = MaterialTheme.typography.subtitle2, fontWeight = FontWeight.Bold)</ID>
     <ID>MaxLineLength:ResolveScreen.kt:Text("VARIANT", Modifier.width(100.dp), style = MaterialTheme.typography.subtitle2, fontWeight = FontWeight.Bold)</ID>
+    <ID>MaxLineLength:ResultsScreen.kt:2 -&gt; sellerFiltered.filter { it.selectedVariant == null || it.selectedVariant?.seller?.isProxy == false }</ID>
     <ID>MaxLineLength:ResultsScreen.kt:Box(Modifier.width(1.dp).height(16.dp).background(MaterialTheme.colors.onSurface.copy(alpha = 0.2f)))</ID>
     <ID>MaxLineLength:ResultsScreen.kt:FilterChip(label = "ALL", isActive = variantTypeFilter == null, activeColor = MaterialTheme.colors.primary, onClick = { variantTypeFilter = null })</ID>
     <ID>MaxLineLength:ResultsScreen.kt:FilterChip(label = label, isActive = proxyFilter == value, activeColor = chipColor, onClick = { proxyFilter = value })</ID>
@@ -351,11 +358,13 @@
     <ID>MaxLineLength:ResultsScreen.kt:if (sortOption == SortOption.PRICE_DESC) Text(" \u25bc", style = MaterialTheme.typography.caption)</ID>
     <ID>MaxLineLength:ResultsScreen.kt:if (sortOption == SortOption.STATUS_ASC) Text(" \u25b2", style = MaterialTheme.typography.caption)</ID>
     <ID>MaxLineLength:ResultsScreen.kt:if (sortOption == SortOption.STATUS_DESC) Text(" \u25bc", style = MaterialTheme.typography.caption)</ID>
+    <ID>MaxLineLength:ResultsScreen.kt:proxyFiltered.filter { it.selectedVariant == null || it.selectedVariant?.variantType == variantTypeFilter }</ID>
     <ID>MaxLineLength:SavedImportQueries.kt:SavedImportQueries$)</ID>
     <ID>MaxLineLength:SavedImportQueries.kt:SavedImportQueries.GetByIdQuery$override</ID>
     <ID>MaxLineLength:ScryfallImageEnricher.kt:ScryfallImageEnricher$log?.invoke("Fetching image for ${variant.nameOriginal} (${variant.setCode} #${variant.collectorNumber})")</ID>
     <ID>MaxLineLength:SellerCacheQueries.kt:SellerCacheQueries$val</ID>
     <ID>MaxLineLength:SellerCacheQueries.kt:SellerCacheQueries.GetCacheQuery$override</ID>
+    <ID>MaxLineLength:ShoppingPlanScreen.kt:color = if (hasLink) MaterialTheme.colors.primary else MaterialTheme.colors.onSurface</ID>
     <ID>MaxLineLength:ShoppingPlanScreen.kt:val mailtoUrl = "mailto:?subject=${encodeUrlParameter(subject)}&amp;body=${encodeUrlParameter(exportText)}"</ID>
     <ID>PackageNaming:MtgPirateDatabaseImpl.kt:package org.srmarlins.mtgpirate.db.MtgPirate</ID>
     <ID>ReturnCount:CatalogParser.kt:CatalogParser$fun extractValue: String?</ID>

--- a/src/commonMain/kotlin/ui/ShoppingPlanScreen.kt
+++ b/src/commonMain/kotlin/ui/ShoppingPlanScreen.kt
@@ -41,10 +41,37 @@ import model.SellerOrder
 import model.ShoppingPlan
 import util.encodeUrlParameter
 import util.formatPrice
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
 
-private const val TCGPLAYER_MASS_ENTRY_URL = "https://www.tcgplayer.com/massentry?productline=Magic"
 private const val BOOTLEG_MAGE_DECK_IMPORT_URL = "https://bootlegmage.com/deck-import/"
-private const val MANAPOOL_URL = "https://manapool.com"
+
+/**
+ * Build TCGPlayer mass entry URL with card list pre-filled via the `c` query parameter.
+ * Cards are separated by `||` which TCGPlayer renders as separate rows.
+ * Format per card: "qty CardName [SET]"
+ */
+private fun buildTcgPlayerUrl(items: List<OrderItem>): String {
+    val cardList = items.joinToString("||") {
+        "${it.qty} ${it.variant.nameOriginal} [${it.variant.setCode}]"
+    }
+    return "https://www.tcgplayer.com/massentry?c=${encodeUrlParameter(cardList)}"
+}
+
+/**
+ * Build ManaPool add-deck URL with card list pre-filled via base64-encoded `deck` parameter.
+ * Format per line: "qty CardName [set] collectorNumber"
+ */
+@OptIn(ExperimentalEncodingApi::class)
+private fun buildManaPoolUrl(items: List<OrderItem>): String {
+    val deckText = items.joinToString("\n") {
+        val cn = it.variant.collectorNumber
+        if (cn != null) "${it.qty} ${it.variant.nameOriginal} [${it.variant.setCode}] $cn"
+        else "${it.qty} ${it.variant.nameOriginal} [${it.variant.setCode}]"
+    }
+    val encoded = Base64.encode(deckText.encodeToByteArray())
+    return "https://manapool.com/add-deck?deck=${encodeUrlParameter(encoded)}"
+}
 
 /**
  * Returns the themed color for a given seller.
@@ -554,10 +581,7 @@ private fun SellerActionButtons(
             Seller.TCGPLAYER -> {
                 PixelButton(
                     text = "Buy on TCGPlayer",
-                    onClick = {
-                        onCopyToClipboard(formatForExport(Seller.TCGPLAYER, order.items))
-                        onOpenUrl(TCGPLAYER_MASS_ENTRY_URL)
-                    },
+                    onClick = { onOpenUrl(buildTcgPlayerUrl(order.items)) },
                     variant = PixelButtonVariant.PRIMARY,
                     modifier = Modifier.weight(1f)
                 )
@@ -574,10 +598,7 @@ private fun SellerActionButtons(
             Seller.MANAPOOL -> {
                 PixelButton(
                     text = "Buy on ManaPool",
-                    onClick = {
-                        onCopyToClipboard(formatForExport(Seller.MANAPOOL, order.items))
-                        onOpenUrl(MANAPOOL_URL)
-                    },
+                    onClick = { onOpenUrl(buildManaPoolUrl(order.items)) },
                     variant = PixelButtonVariant.PRIMARY,
                     modifier = Modifier.weight(1f)
                 )


### PR DESCRIPTION
## Summary
Closes #162

- **One-click Buy buttons**: "Buy on [Seller]" copies the formatted card list to clipboard AND opens the seller's purchase page simultaneously — no more two-step copy-then-open
- **Clickable card rows**: Individual cards with a `purchaseUri` (TCGPlayer, ManaPool) show as clickable links with a ↗ icon, opening the card's product page directly
- **Copy feedback**: Secondary "Copy List"/"Copy CSV" buttons show "Copied!" after clicking
- **USEA Email Order**: Now also copies CSV to clipboard alongside opening the email compose

## Test plan
- [ ] Click "Buy on TCGPlayer" — list copied to clipboard, TCGPlayer mass entry opens
- [ ] Click "Buy on Bootleg Mage" — list copied, deck import page opens
- [ ] Click "Buy on ManaPool" — list copied, ManaPool opens
- [ ] Click "Email Order" (USEA) — CSV copied, email compose opens
- [ ] Click individual card name in expanded list — opens product page if available
- [ ] Click "Copy List" — shows "Copied!" feedback