### PR TITLE
fix: refresh multiMatches from catalog so alt detail shows images

### DIFF
--- a/src/commonMain/kotlin/state/CatalogUseCase.kt
+++ b/src/commonMain/kotlin/state/CatalogUseCase.kt
@@ -282,4 +282,38 @@ class CatalogUseCase(
             )
         }
     }
+
+    /**
+     * Refresh multi-match data with the latest variant information from the catalog.
+     *
+     * Same purpose as [refreshMatchesFromCatalog] but for [model.MultiMatch] objects
+     * used by the alt detail screen and shopping optimizer.
+     */
+    fun refreshMultiMatchesFromCatalog(
+        multiMatches: List<model.MultiMatch>,
+        catalog: Catalog
+    ): List<model.MultiMatch> {
+        if (multiMatches.isEmpty() || catalog.variants.isEmpty()) return multiMatches
+
+        val variantsBySku = catalog.variants.associateBy { it.sku }
+
+        return multiMatches.map { mm ->
+            val refreshedBest = mm.bestOption?.let { refreshMatchOption(it, variantsBySku) }
+            val refreshedAlts = mm.alternatives.map { refreshMatchOption(it, variantsBySku) }
+            val refreshedFallback = mm.realCardFallback?.let { refreshMatchOption(it, variantsBySku) }
+            mm.copy(
+                bestOption = refreshedBest,
+                alternatives = refreshedAlts,
+                realCardFallback = refreshedFallback,
+            )
+        }
+    }
+
+    private fun refreshMatchOption(
+        option: model.MatchOption,
+        variantsBySku: Map<String, model.CardVariant>,
+    ): model.MatchOption {
+        val refreshed = variantsBySku[option.variant.sku] ?: option.variant
+        return option.copy(variant = refreshed)
+    }
 }

--- a/src/commonMain/kotlin/state/MviViewModel.kt
+++ b/src/commonMain/kotlin/state/MviViewModel.kt
@@ -82,11 +82,20 @@ class MviViewModel(
 
         // Subscribe to database flows and combine into ViewState
         // No outer scope.launch needed — launchIn(scope) handles collection
+        val catalogFlow = database.observeCatalog().distinctUntilChanged()
+
         val refreshedMatchesFlow = combine(
-            database.observeCatalog().distinctUntilChanged(),
+            catalogFlow,
             _localState.map { it.matches }.distinctUntilChanged()
         ) { catalog, matches ->
             catalogUseCase.refreshMatchesFromCatalog(matches, catalog)
+        }
+
+        val refreshedMultiMatchesFlow = combine(
+            catalogFlow,
+            _localState.map { it.multiMatches }.distinctUntilChanged()
+        ) { catalog, multiMatches ->
+            catalogUseCase.refreshMultiMatchesFromCatalog(multiMatches, catalog)
         }
 
         // Derive match counts reactively from matches
@@ -95,9 +104,11 @@ class MviViewModel(
             .distinctUntilChanged()
             .map { matchingUseCase.calculateMatchCounts(it) }
 
-        // Group refreshedMatches + counts to stay within combine's 5-param limit
-        val derivedFlow = combine(refreshedMatchesFlow, matchCountsFlow) { refreshed, counts ->
-            refreshed to counts
+        // Group refreshedMatches + counts + multiMatches to stay within combine's 5-param limit
+        val derivedFlow = combine(
+            refreshedMatchesFlow, matchCountsFlow, refreshedMultiMatchesFlow
+        ) { refreshed, counts, refreshedMulti ->
+            Triple(refreshed, counts, refreshedMulti)
         }
 
         combine(
@@ -106,7 +117,7 @@ class MviViewModel(
             database.observeSavedImports(),
             _localState,
             derivedFlow
-        ) { catalog, preferences, savedImports, localState, (refreshedMatches, counts) ->
+        ) { catalog, preferences, savedImports, localState, (refreshedMatches, counts, refreshedMultiMatches) ->
             ViewState(
                 catalog = if (catalog.variants.isEmpty()) null else catalog,
                 preferences = preferences,
@@ -133,7 +144,7 @@ class MviViewModel(
                 unmatchedCount = counts.unmatched,
                 ambiguousCount = counts.ambiguous,
                 totalPriceCents = counts.totalPrice,
-                multiMatches = localState.multiMatches,
+                multiMatches = refreshedMultiMatches,
                 shoppingPlan = localState.shoppingPlan,
                 availableSellers = localState.availableSellers,
                 loadingMultiCatalogs = localState.searchProgress?.isSearching ?: localState.loadingMultiCatalogs,


### PR DESCRIPTION
## Summary

- `multiMatches` was sourced directly from `_localState` snapshots, so when `ImagePrefetchService` wrote image URLs to the DB, the reactive `observeCatalog()` flow refreshed `matches` but not `multiMatches`
- Add `refreshMultiMatchesFromCatalog` to `CatalogUseCase` — same pattern as the existing `refreshMatchesFromCatalog` but for `MultiMatch` objects
- Wire the new refresh into the ViewModel's reactive combine block so alt detail screen picks up DB-updated image URLs

## Test plan

- [x] `./gradlew build` passes (compile + detekt + all tests)
- [ ] Launch app, import deck, run multi-seller search
- [ ] Navigate to alt detail screen — card images should now load
- [ ] Verify results screen images still work

Closes #181